### PR TITLE
[FIX] Prevent segmentation fault with --no-lb and --verbose/trace

### DIFF
--- a/pkg/client/ports.go
+++ b/pkg/client/ports.go
@@ -100,8 +100,9 @@ func TransformPorts(ctx context.Context, runtime runtimes.Runtime, cluster *k3d.
 
 	}
 
-	// print generated loadbalancer config
-	if l.Log().GetLevel() >= logrus.DebugLevel {
+	// print generated loadbalancer config if exists
+	// (avoid segmentation fault if loadbalancer is disabled)
+	if l.Log().GetLevel() >= logrus.DebugLevel && cluster.ServerLoadBalancer != nil {
 		yamlized, err := yaml.Marshal(cluster.ServerLoadBalancer.Config)
 		if err != nil {
 			l.Log().Errorf("error printing loadbalancer config: %v", err)


### PR DESCRIPTION
# What

Prevents segmentation fault error when `--no-lb` and `--verbose` or `--trace` options are passed. (Code previously tried to marshal non-existent config.)

# Why

fixes https://github.com/rancher/k3d/issues/750

# Implications

Allows `--no-lb` and `--verbose` or `--trace` options to be passed at the same time, allowing for debugging of `--no-lb` problems.

@all-contributors please add benjaminjb for code