### PR TITLE
Correct nodefilters to use brackets

### DIFF
--- a/docs/usage/exposing_services.md
+++ b/docs/usage/exposing_services.md
@@ -62,10 +62,10 @@ Therefore, we have to create the cluster in a way, that the internal port 80 (wh
 
 1. Create a cluster, mapping the port `30080` from `agent-0` to `localhost:8082`
 
-  `#!bash k3d cluster create mycluster -p "8082:30080@agent:0" --agents 2`
+  `#!bash k3d cluster create mycluster -p "8082:30080@agent[0]" --agents 2`
 
   - **Note 1**: Kubernetes' default NodePort range is [`30000-32767`](https://kubernetes.io/docs/concepts/services-networking/service/#nodeport)
-  - **Note 2**: You may as well expose the whole NodePort range from the very beginning, e.g. via `k3d cluster create mycluster --agents 3 -p "30000-32767:30000-32767@server:0"` (See [this video from @portainer](https://www.youtube.com/watch?v=5HaU6338lAk))
+  - **Note 2**: You may as well expose the whole NodePort range from the very beginning, e.g. via `k3d cluster create mycluster --agents 3 -p "30000-32767:30000-32767@server[0]"` (See [this video from @portainer](https://www.youtube.com/watch?v=5HaU6338lAk))
     - **Warning**: Docker creates iptable entries and a new proxy process per port-mapping, so this may take a very long time or even freeze your system!
 
     ... (Steps 2 and 3 like above) ...


### PR DESCRIPTION
As written, the example produces the error:
`FATA[0000] Failed to parse node filters: invalid format or empty subset in 'server:0'`

This corrects the example to use the same bracket syntax as is mentioned in `k3d cluster create --help`