### PR TITLE
refactor: move from io/ioutil to io and os package

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -25,7 +25,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -167,7 +166,7 @@ func initLogging() {
 			l.Log().SetLevel(logrus.InfoLevel)
 		}
 	}
-	l.Log().SetOutput(ioutil.Discard)
+	l.Log().SetOutput(io.Discard)
 	l.Log().AddHook(&writer.Hook{
 		Writer: os.Stderr,
 		LogLevels: []logrus.Level{

--- a/cmd/util/config/config.go
+++ b/cmd/util/config/config.go
@@ -23,7 +23,6 @@ package config
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -58,7 +57,7 @@ func InitViperWithConfigFile(cfgViper *viper.Viper, configFile string) error {
 		}
 		defer tmpfile.Close()
 
-		originalcontent, err := ioutil.ReadFile(configFile)
+		originalcontent, err := os.ReadFile(configFile)
 		if err != nil {
 			l.Log().Fatalf("error reading config file %s: %v", configFile, err)
 		}

--- a/pkg/actions/nodehooks.go
+++ b/pkg/actions/nodehooks.go
@@ -25,7 +25,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 
 	"github.com/rancher/k3d/v5/pkg/runtimes"
@@ -59,7 +59,7 @@ func (act RewriteFileAction) Run(ctx context.Context, node *k3d.Node) error {
 	}
 	defer reader.Close()
 
-	file, err := ioutil.ReadAll(reader)
+	file, err := io.ReadAll(reader)
 	if err != nil {
 		return fmt.Errorf("failed to read file: %w", err)
 	}

--- a/pkg/client/cluster.go
+++ b/pkg/client/cluster.go
@@ -27,7 +27,7 @@ import (
 	_ "embed"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"sort"
 	"strconv"
@@ -1078,7 +1078,7 @@ func corednsAddHost(ctx context.Context, runtime k3drt.Runtime, cluster *k3d.Clu
 		} else {
 			msg := fmt.Sprintf("(try %d/%d) error patching the CoreDNS ConfigMap to include entry '%s': %+v", i, retries, hostsEntry, err)
 			if logreader != nil {
-				readlogs, err := ioutil.ReadAll(logreader)
+				readlogs, err := io.ReadAll(logreader)
 				if err != nil {
 					l.Log().Debugf("(try %d/%d) error reading the logs from failed CoreDNS patch exec process in node %s: %v", i, retries, node.Name, err)
 				} else {

--- a/pkg/client/kubeconfig.go
+++ b/pkg/client/kubeconfig.go
@@ -25,7 +25,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"time"
@@ -147,7 +147,7 @@ func KubeconfigGet(ctx context.Context, runtime runtimes.Runtime, cluster *k3d.C
 	}
 	defer reader.Close()
 
-	readBytes, err := ioutil.ReadAll(reader)
+	readBytes, err := io.ReadAll(reader)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read kubeconfig file: %w", err)
 	}

--- a/pkg/client/loadbalancer.go
+++ b/pkg/client/loadbalancer.go
@@ -26,7 +26,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"strings"
 	"time"
 
@@ -134,7 +134,7 @@ func GetLoadbalancerConfig(ctx context.Context, runtime runtimes.Runtime, cluste
 	}
 	defer reader.Close()
 
-	file, err := ioutil.ReadAll(reader)
+	file, err := io.ReadAll(reader)
 	if err != nil {
 		return cfg, fmt.Errorf("failed to read loadbalancer config file: %w", err)
 	}

--- a/pkg/client/node.go
+++ b/pkg/client/node.go
@@ -28,7 +28,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"reflect"
 	"strconv"
@@ -156,7 +156,7 @@ func NodeAddToCluster(ctx context.Context, runtime runtimes.Runtime, node *k3d.N
 		defer registryConfigReader.Close()
 
 		var err error
-		registryConfigBytes, err = ioutil.ReadAll(registryConfigReader)
+		registryConfigBytes, err = io.ReadAll(registryConfigReader)
 		if err != nil {
 			l.Log().Warnf("Failed to read registry config from node %s: %+v", node.Name, err)
 		}

--- a/pkg/client/tools_test.go
+++ b/pkg/client/tools_test.go
@@ -24,7 +24,6 @@ package client
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -178,7 +177,7 @@ func Test_findRuntimeImage(T *testing.T) {
 
 func Test_findImages(t *testing.T) {
 	// given
-	tarImage, err := ioutil.TempFile("", "images.tgz")
+	tarImage, err := os.CreateTemp("", "images.tgz")
 	if err != nil {
 		t.Fatal("Failed to create temporary file")
 	}

--- a/pkg/config/jsonschema.go
+++ b/pkg/config/jsonschema.go
@@ -25,7 +25,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 
 	"sigs.k8s.io/yaml"
@@ -39,7 +39,7 @@ import (
 func ValidateSchemaFile(filepath string, schema []byte) error {
 	l.Log().Debugf("Validating file %s against default JSONSchema...", filepath)
 
-	fileContents, err := ioutil.ReadFile(filepath)
+	fileContents, err := os.ReadFile(filepath)
 	if err != nil {
 		return fmt.Errorf("Failed to read file %s: %+v", filepath, err)
 	}

--- a/pkg/config/transform.go
+++ b/pkg/config/transform.go
@@ -25,7 +25,7 @@ package config
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"strings"
 
@@ -336,7 +336,7 @@ func TransformSimpleToClusterConfig(ctx context.Context, runtime runtimes.Runtim
 			if err != nil {
 				return nil, fmt.Errorf("failed to open registry config file at %s: %w", simpleConfig.Registries.Config, err)
 			}
-			configBytes, err := ioutil.ReadAll(registryConfigFile)
+			configBytes, err := io.ReadAll(registryConfigFile)
 			if err != nil {
 				return nil, fmt.Errorf("failed to read registry config file at %s: %w", registryConfigFile.Name(), err)
 			}

--- a/pkg/runtimes/docker/container.go
+++ b/pkg/runtimes/docker/container.go
@@ -26,7 +26,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 
 	"github.com/docker/docker/api/types"
@@ -119,7 +118,7 @@ func pullImage(ctx context.Context, docker *client.Client, image string) error {
 	l.Log().Infof("Pulling image '%s'", image)
 
 	// in debug mode (--verbose flag set), output pull progress
-	var writer io.Writer = ioutil.Discard
+	var writer io.Writer = io.Discard
 	if l.Log().GetLevel() == logrus.DebugLevel {
 		writer = os.Stdout
 	}

--- a/pkg/runtimes/docker/node.go
+++ b/pkg/runtimes/docker/node.go
@@ -28,7 +28,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"time"
 
 	"github.com/docker/docker/api/types"
@@ -331,7 +330,7 @@ func (d Docker) ExecInNode(ctx context.Context, node *k3d.Node, cmd []string) er
 	}
 	if err != nil {
 		if execConnection != nil && execConnection.Reader != nil {
-			logs, err := ioutil.ReadAll(execConnection.Reader)
+			logs, err := io.ReadAll(execConnection.Reader)
 			if err != nil {
 				return fmt.Errorf("failed to get logs from errored exec process in node '%s': %w", node.Name, err)
 			}


### PR DESCRIPTION
# What

This PR replaces the existing `io/ioutil` functions with their new definitions in `io` and `os` packages.

# Why

The `io/ioutil` package has been deprecated in Go 1.16 (See https://golang.org/doc/go1.16#ioutil). Since k3d has been upgraded to Go 1.17 (5aa1edfb732785f8b64c84d40a0faccd57e9357f), we can remove the usage of `io/ioutil` package.

# Implications

No breaking changes.
