### PR TITLE
[Fix] Fix docker client creation by tls verify from env

### DIFF
--- a/pkg/runtimes/docker/container.go
+++ b/pkg/runtimes/docker/container.go
@@ -107,7 +107,7 @@ func removeContainer(ctx context.Context, ID string) error {
 }
 
 // pullImage pulls a container image and outputs progress if --verbose flag is set
-func pullImage(ctx context.Context, docker *client.Client, image string) error {
+func pullImage(ctx context.Context, docker client.APIClient, image string) error {
 
 	resp, err := docker.ImagePull(ctx, image, types.ImagePullOptions{})
 	if err != nil {


### PR DESCRIPTION
Follow-Up for https://github.com/rancher/k3d/pull/674

support with TLS (via env `DOCKER_TLS_VERIFY`)
support with TLS (via context)

as alreay called 

```go
dockerCli.Initialize(newClientOpts)
```

why not use client inside dockerCli created by function Initialize

fixes #801 