### PR TITLE
ci/action/arch: Switch from absolute Arch docker version to a more relaxed one

### DIFF
--- a/.github/workflows/aur-prerelease.yml
+++ b/.github/workflows/aur-prerelease.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   aur-pre-release:
     runs-on: ubuntu-20.04
-    container: archlinux:base-20210228.0.16308
+    container: archlinux:base
     steps:
       - name: Checkout Project
         uses: actions/checkout@v1

--- a/.github/workflows/aur-release.yml
+++ b/.github/workflows/aur-release.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   aur-release:
     runs-on: ubuntu-20.04
-    container: archlinux:base-20210228.0.16308
+    container: archlinux:base
     steps:
       - name: Checkout Project
         uses: actions/checkout@v1

--- a/deploy-aur.sh
+++ b/deploy-aur.sh
@@ -3,7 +3,7 @@
 set -e
 
 # Setup base system
-pacman -Syu --noconfirm openssh git gettext binutils
+pacman -Syu --noconfirm openssh git gettext binutils archlinux-keyring
 sed -i "s/INTEGRITY_CHECK=.*$/INTEGRITY_CHECK=(sha256)/" /etc/makepkg.conf
 useradd -ms /bin/bash aur
 su -m aur <<'EOSU'


### PR DESCRIPTION
<!-- 
Hi there, have an early THANK YOU for your contribution!
k3d is a community-driven project, so we really highly appreciate any support.
Please make sure, you've read our Code of Conduct and the Contributing Guidelines :)
- Code of Conduct: https://github.com/rancher/k3d/blob/main/CODE_OF_CONDUCT.md
- Contributing Guidelines: https://github.com/rancher/k3d/blob/main/CONTRIBUTING.md
-->

# What

Relaxing the Arch Linux docker version in the deploy script. In the end we're not depending on specific packages of Arch Linux since we install most of them ourselves. This should prevent builds breaking like it currently does, because of outdated keys or similar.

~~The alternative would be to use sth like `pacman-key --refresh-keys`, but this takes always takes a while...~~

EDIT: I pushed another commit which will update `archlinux-keyring` when the deploy starts, which automatically gets all the latest keys.

# Why

Breaking deploy scripts to AUR

# Implications

- 