### PR TITLE
fix: Use bridge as the default networking mode

### DIFF
--- a/pkg/runtimes/docker/translate.go
+++ b/pkg/runtimes/docker/translate.go
@@ -57,6 +57,10 @@ func TranslateNodeToContainer(node *k3d.Node) (*NodeInDocker, error) {
 	hostConfig := docker.HostConfig{
 		Init:       &init,
 		ExtraHosts: node.ExtraHosts,
+		// Explicitly require bridge networking. Podman incorrectly uses
+		// slirp4netns when running rootless, therefore for rootless podman to
+		// work, this must be set.
+		NetworkMode: "bridge",
 	}
 	networkingConfig := network.NetworkingConfig{}
 


### PR DESCRIPTION
Improves compatibility with rootless Podman

<!-- 
Hi there, have an early THANK YOU for your contribution!
k3d is a community-driven project, so we really highly appreciate any support.
Please make sure, you've read our Code of Conduct and the Contributing Guidelines :)
- Code of Conduct: https://github.com/k3d-io/k3d/blob/main/CODE_OF_CONDUCT.md
- Contributing Guidelines: https://github.com/k3d-io/k3d/blob/main/CONTRIBUTING.md
-->

# What

<!-- What does this PR do or change? -->
Sets the default `NetworkMode` to `bridge`.

# Why

<!-- Link issues, discussions, etc. or just explain why you're creating this PR -->
- Some users might like to use `k3d` with Podman (See #84)
- Podman currently [defaults](https://github.com/containers/podman/blob/ccb96a2791fe9ae58a697bf1715600ecec8b246b/pkg/specgen/namespaces.go#L355-L359) to `slirp4netns` when running as a rootless service.
  - Changing this default behaviour in Podman might break other users of the Podman API.

# Implications

<!--
Does this change existing behavior? If so, does it affect the CLI (cmd/) only or does it also/only change some internals of the Go module (pkg/)?
Especially mention breaking changes here!
-->
- Might break usage with runtimes without support for bridge networks (Is this a thing?)

<!-- Get recognized using our all-contributors bot: https://github.com/k3d-io/k3d/blob/main/CONTRIBUTING.md#get-recognized -->
