### PR TITLE
install.sh: Invoke curl with secure defaults

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -51,7 +51,7 @@ scurl() {
   # - `--fail` ensures that the command fails if HTTP response is not 2xx.
   # - `--show-error` causes curl to output error messages when it fails (when
   #   also invoked with -s|--silent).
-  curl --proto =https --tlsv1.2 --fail --show-error "$@"
+  curl --proto "=https" --tlsv1.2 --fail --show-error "$@"
 }
 
 # verifySupported checks that the os/arch combination is supported for


### PR DESCRIPTION
When invoking the install script, the installation process can fail
silently so that the `k3d` binary includes only the ASCII string 'Not
found'. This can be avoided by passing the `--fail` flag so that the
command fails if a 4XX or 5XX response is received.

This change adds a `scurl` function that invokes `curl` with this flag,
as well as flags that ensure that at least TLS v1.2 is used (this helps
mitigate protocol downgrade attacks).

This is based on the defaults we use in Linkerd. See: https://github.com/linkerd/linkerd2/blob/a0b112471eef7e3975fbc8564df52d83894c3fa3/bin/scurl