### PR TITLE
add: node create --k3s-arg flag

### DIFF
--- a/cmd/node/nodeCreate.go
+++ b/cmd/node/nodeCreate.go
@@ -90,6 +90,8 @@ func NewCmdNodeCreate() *cobra.Command {
 
 	cmd.Flags().StringVarP(&createNodeOpts.ClusterToken, "token", "t", "", "Override cluster token (required when connecting to an external cluster)")
 
+	cmd.Flags().StringArray("k3s-arg", nil, "Additional args passed to k3d command")
+
 	// done
 	return cmd
 }
@@ -180,6 +182,12 @@ func parseCreateNodeCmd(cmd *cobra.Command, args []string) ([]*k3d.Node, string)
 		l.Log().Fatalf("failed to get --network string slice flag: %v", err)
 	}
 
+	// --k3s-arg
+	k3sArgs, err := cmd.Flags().GetStringArray("k3s-arg")
+	if err != nil {
+		l.Log().Fatalf("failed to get --k3s-arg string array flag: %v", err)
+	}
+
 	// generate list of nodes
 	nodes := []*k3d.Node{}
 	for i := 0; i < replicas; i++ {
@@ -192,6 +200,7 @@ func parseCreateNodeCmd(cmd *cobra.Command, args []string) ([]*k3d.Node, string)
 			Restart:       true,
 			Memory:        memory,
 			Networks:      networks,
+			Args:          k3sArgs,
 		}
 		nodes = append(nodes, node)
 	}


### PR DESCRIPTION
fixes #716

```bash
$ k3d cluster create test -a 1
...

$ k3d node create testnode2 --role agent --cluster test --k3s-arg '--node-label=foo=bar'
...

$ docker inspect k3d-testnode2-0
...
"Cmd": [
                "agent",
                "--node-label=foo=bar"
            ],
...

$ k3d node create testnode3 --role agent --cluster test --k3s-arg '--node-label=spam=eggs'
...

$ kubectl get nodes --show-labels                                                                                      
NAME                STATUS   ROLES                  AGE     VERSION        LABELS
k3d-testnode2-0     Ready    <none>                 4m11s   v1.22.7+k3s1   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/instance-type=k3s,beta.kubernetes.io/os=linux,foo=bar,kubernetes.io/arch=amd64,kubernetes.io/hostname=k3d-testnode2-0,kubernetes.io/os=linux,node.kubernetes.io/instance-type=k3s
k3d-testnode3-0     Ready    <none>                 3m44s   v1.22.7+k3s1   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/instance-type=k3s,beta.kubernetes.io/os=linux,foo=bar,kubernetes.io/arch=amd64,kubernetes.io/hostname=k3d-testnode3-0,kubernetes.io/os=linux,node.kubernetes.io/instance-type=k3s,spam=eggs
k3d-test-agent-0    Ready    <none>                 8m47s   v1.22.7+k3s1   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/instance-type=k3s,beta.kubernetes.io/os=linux,kubernetes.io/arch=amd64,kubernetes.io/hostname=k3d-test-agent-0,kubernetes.io/os=linux,node.kubernetes.io/instance-type=k3s
k3d-test-server-0   Ready    control-plane,master   8m52s   v1.22.7+k3s1   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/instance-type=k3s,beta.kubernetes.io/os=linux,kubernetes.io/arch=amd64,kubernetes.io/hostname=k3d-test-server-0,kubernetes.io/os=linux,node-role.kubernetes.io/control-plane=true,node-role.kubernetes.io/master=true,node.kubernetes.io/instance-type=k3s

```