### PR TITLE
make: Use `go install` instead of `go get` for installing tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -199,7 +199,7 @@ HAS_GOLANGCI_VERSION := $(shell golangci-lint --version | grep "version $(PKG_GO
 
 install-tools:
 ifndef HAS_GOX
-	($(GO) get $(PKG_GOX))
+	($(GO) install $(PKG_GOX))
 endif
 ifndef HAS_GOLANGCI
 	(curl -sfL $(PKG_GOLANGCI_LINT_SCRIPT) | sh -s -- -b $(GOENVPATH)/bin v${PKG_GOLANGCI_LINT_VERSION})


### PR DESCRIPTION
Using `go get` for installing binaries/tools is deprecated and it's
littering the local go.mod and vendor.txt files. This change fixes that
by using `go install` instead.

Signed-off-by: Michal Rostecki <vadorovsky@gmail.com>

<!-- 
Hi there, have an early THANK YOU for your contribution!
k3d is a community-driven project, so we really highly appreciate any support.
Please make sure, you've read our Code of Conduct and the Contributing Guidelines :)
- Code of Conduct: https://github.com/k3d-io/k3d/blob/main/CODE_OF_CONDUCT.md
- Contributing Guidelines: https://github.com/k3d-io/k3d/blob/main/CONTRIBUTING.md
-->

# What

<!-- What does this PR do or change? -->
It changes `go get` usage to `go install` for fetching a binary tool.

# Why

<!-- Link issues, discussions, etc. or just explain why you're creating this PR -->
Using `go get` for that purpose is deprecated and makes unnecessary changes in go.mod (thinking that you are going to use the mentioned project as a dependency).

# Implications

<!--
Does this change existing behavior? If so, does it affect the CLI (cmd/) only or does it also/only change some internals of the Go module (pkg/)?
Especially mention breaking changes here!
-->
There should be no implications for developers using recent Go vesions.

<!-- Get recognized using our all-contributors bot: https://github.com/k3d-io/k3d/blob/main/CONTRIBUTING.md#get-recognized -->
