### PR TITLE
Feature: Add plugin system - plugin execution

### DIFF
--- a/cmd/plugin/plugin.go
+++ b/cmd/plugin/plugin.go
@@ -26,7 +26,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// NewCmdNode returns a new cobra command
+// NewCmdPlugin NewCmdNode returns a new cobra command
 func NewCmdPlugin() *cobra.Command {
 
 	// create new cobra command

--- a/cmd/plugin/plugin.go
+++ b/cmd/plugin/plugin.go
@@ -1,0 +1,54 @@
+/*
+Copyright © 2020-2022 The k3d Author(s)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package plugin
+
+import (
+	l "github.com/k3d-io/k3d/v5/pkg/logger"
+	"github.com/spf13/cobra"
+)
+
+// NewCmdNode returns a new cobra command
+func NewCmdPlugin() *cobra.Command {
+
+	// create new cobra command
+	cmd := &cobra.Command{
+		Use:   "plugin",
+		Short: "Manage plugin(s)",
+		Long:  `Manage plugin(s)`,
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := cmd.Help(); err != nil {
+				l.Log().Errorln("Couldn't get help text")
+				l.Log().Fatalln(err)
+			}
+		},
+	}
+
+	// add subcommands
+	cmd.AddCommand(
+		NewCmdPluginList(),
+	)
+
+	// add flags
+
+	// done
+	return cmd
+}

--- a/cmd/plugin/pluginList.go
+++ b/cmd/plugin/pluginList.go
@@ -1,0 +1,94 @@
+/*
+Copyright © 2020-2022 The k3d Author(s)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package plugin
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	l "github.com/k3d-io/k3d/v5/pkg/logger"
+	"github.com/k3d-io/k3d/v5/pkg/plugin"
+	k3dPlugin "github.com/k3d-io/k3d/v5/pkg/plugin"
+	tabwriter "github.com/liggitt/tabwriter"
+	"github.com/spf13/cobra"
+)
+
+type pluginListFlags struct {
+	noHeader bool
+}
+
+func NewCmdPluginList() *cobra.Command {
+	pluginListFlags := pluginListFlags{}
+
+	cmd := &cobra.Command{
+		Use:     "list",
+		Aliases: []string{"ls", "get"},
+		Short:   "List plugin(s)",
+		Long:    "List plugin(s)",
+		Args:    cobra.MinimumNArgs(0), // 0 or more; 0 = all
+		Run: func(cmd *cobra.Command, args []string) {
+			userHomeDir, err := os.UserHomeDir()
+			if err != nil {
+				l.Log().Fatalln(err)
+			}
+
+			// TODO: Override this variables from cobra/viper or using env vars
+			pluginPath := filepath.Join(userHomeDir, ".k3d", "plugins")
+			manifestName := plugin.DefaultManifestName
+
+			plugins, err := k3dPlugin.LoadAll(pluginPath, manifestName)
+			if err != nil {
+				l.Log().Fatalln(err)
+			}
+
+			PrintPlugins(plugins, pluginListFlags)
+		},
+	}
+
+	// add subcommands
+
+	// add flags
+	cmd.Flags().BoolVar(&pluginListFlags.noHeader, "no-headers", false, "Disable headers")
+
+	return cmd
+}
+
+func PrintPlugins(plugins []*k3dPlugin.Plugin, flags pluginListFlags) {
+	headers := &[]string{}
+	if !flags.noHeader {
+		headers = &[]string{"NAME", "VERSION", "DESCRIPTION"}
+	}
+
+	tabwriter := tabwriter.NewWriter(os.Stdout, 6, 4, 3, ' ', tabwriter.RememberWidths)
+	defer tabwriter.Flush()
+
+	_, err := fmt.Fprintf(tabwriter, "%s\n", strings.Join(*headers, "\t"))
+	if err != nil {
+		l.Log().Fatalln("Failed to print headers")
+	}
+
+	for _, plugin := range plugins {
+		fmt.Fprintf(tabwriter, "%s\t%s\t%s\n", plugin.Manifest.Name, plugin.Manifest.Version, plugin.Manifest.ShortHelpMessage)
+	}
+}

--- a/cmd/plugin/pluginList.go
+++ b/cmd/plugin/pluginList.go
@@ -38,6 +38,7 @@ type pluginListFlags struct {
 	noHeader bool
 }
 
+// NewCmdPluginList create a Cobra command to list plugins
 func NewCmdPluginList() *cobra.Command {
 	pluginListFlags := pluginListFlags{}
 
@@ -80,15 +81,15 @@ func PrintPlugins(plugins []*k3dPlugin.Plugin, flags pluginListFlags) {
 		headers = &[]string{"NAME", "VERSION", "DESCRIPTION"}
 	}
 
-	tabwriter := tabwriter.NewWriter(os.Stdout, 6, 4, 3, ' ', tabwriter.RememberWidths)
-	defer tabwriter.Flush()
+	writer := tabwriter.NewWriter(os.Stdout, 6, 4, 3, ' ', tabwriter.RememberWidths)
+	defer writer.Flush()
 
-	_, err := fmt.Fprintf(tabwriter, "%s\n", strings.Join(*headers, "\t"))
+	_, err := fmt.Fprintf(writer, "%s\n", strings.Join(*headers, "\t"))
 	if err != nil {
 		l.Log().Fatalln("Failed to print headers")
 	}
 
-	for _, plugin := range plugins {
-		fmt.Fprintf(tabwriter, "%s\t%s\t%s\n", plugin.Manifest.Name, plugin.Manifest.Version, plugin.Manifest.ShortHelpMessage)
+	for _, p := range plugins {
+		fmt.Fprintf(writer, "%s\t%s\t%s\n", p.Manifest.Name, p.Manifest.Version, p.Manifest.ShortHelpMessage)
 	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -42,6 +42,7 @@ import (
 	"github.com/k3d-io/k3d/v5/cmd/image"
 	"github.com/k3d-io/k3d/v5/cmd/kubeconfig"
 	"github.com/k3d-io/k3d/v5/cmd/node"
+	plugin "github.com/k3d-io/k3d/v5/cmd/plugin"
 	"github.com/k3d-io/k3d/v5/cmd/registry"
 	cliutil "github.com/k3d-io/k3d/v5/cmd/util"
 	l "github.com/k3d-io/k3d/v5/pkg/logger"
@@ -100,6 +101,7 @@ All Nodes of a k3d cluster are part of the same docker network.`,
 		cfg.NewCmdConfig(),
 		registry.NewCmdRegistry(),
 		debug.NewCmdDebug(),
+		plugin.NewCmdPlugin(),
 		&cobra.Command{
 			Use:   "runtime-info",
 			Short: "Show runtime information",

--- a/pkg/plugin/manifest.go
+++ b/pkg/plugin/manifest.go
@@ -1,0 +1,39 @@
+/*
+Copyright © 2020-2022 The k3d Author(s)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package plugin
+
+// PluginFileName is the name of the manifest file that describes the plugin
+const DefaultManifestName = "k3d-plugin.yaml"
+
+// PluginManifest describes plugin attributes
+type Manifest struct {
+	Name             string `yaml:"name"`
+	Version          string `yaml:"version"`
+	ShortHelpMessage string `yaml:"shortHelpMessage"`
+	HelpMessage      string `yaml:"helpMessage"`
+	Command          string `yaml:"command"`
+}
+
+type Plugin struct {
+	Manifest  *Manifest
+	Directory string
+}

--- a/pkg/plugin/manifest.go
+++ b/pkg/plugin/manifest.go
@@ -21,10 +21,10 @@ THE SOFTWARE.
 */
 package plugin
 
-// PluginFileName is the name of the manifest file that describes the plugin
+// DefaultManifestName is the name of the manifest file that describes the plugin
 const DefaultManifestName = "k3d-plugin.yaml"
 
-// PluginManifest describes plugin attributes
+// Manifest PluginManifest describes plugin attributes
 type Manifest struct {
 	Name             string `yaml:"name"`
 	Version          string `yaml:"version"`

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -1,0 +1,89 @@
+/*
+Copyright © 2020-2022 The k3d Author(s)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package plugin
+
+import (
+	"io/ioutil"
+	"path/filepath"
+
+	l "github.com/k3d-io/k3d/v5/pkg/logger"
+	"github.com/pkg/errors"
+	"gopkg.in/yaml.v2"
+)
+
+// listSubdirs returns a list of folders inside basepath
+func listSubdirs(basepath string) ([]string, error) {
+	globPath := filepath.Join(basepath, "*")
+	subdirs, err := filepath.Glob(globPath)
+	if err != nil {
+		return nil, errors.Wrapf(err, "Error while listing subdirectories of %s", basepath)
+	}
+
+	return subdirs, nil
+}
+
+// LoadOne loads the plugin located in manifestPath
+func LoadOne(manifestPath string) (*Plugin, error) {
+	data, err := ioutil.ReadFile(manifestPath)
+	if err != nil {
+		return nil, errors.Wrapf(err, "Error while loading %s plugin", manifestPath)
+	}
+
+	plugin := &Plugin{}
+
+	// Load plugin manifest
+	err = yaml.UnmarshalStrict(data, &plugin.Manifest)
+	if err != nil {
+		return nil, errors.Wrapf(err, "Error while unmarshalling plugin at %s", manifestPath)
+	}
+	// Set plugin directory
+	plugin.Directory = filepath.Dir(manifestPath)
+
+	return plugin, nil
+}
+
+// LoadAll loads all plugins inside the specified pluginsPath
+func LoadAll(pluginsPath, manifestName string) ([]*Plugin, error) {
+	pluginDirectories, err := listSubdirs(pluginsPath)
+	if err != nil {
+		return nil, err
+	}
+	l.Log().Debugf("Read subdirectory of %s, found %d subdir(s)", pluginsPath, len(pluginDirectories))
+
+	plugins := []*Plugin{}
+
+	for _, dir := range pluginDirectories {
+		manifestPath := filepath.Join(dir, manifestName)
+		l.Log().Debugf("Loading %s", manifestPath)
+
+		plugin, err := LoadOne(manifestPath)
+		if err != nil {
+			return nil, err
+		}
+
+		l.Log().Debugf("%s loaded", plugin.Manifest.Name)
+
+		plugins = append(plugins, plugin)
+	}
+
+	return plugins, nil
+}

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -69,7 +69,7 @@ func LoadAll(pluginsPath, manifestName string) ([]*Plugin, error) {
 	}
 	l.Log().Debugf("Read subdirectory of %s, found %d subdir(s)", pluginsPath, len(pluginDirectories))
 
-	plugins := []*Plugin{}
+	var plugins []*Plugin
 
 	for _, dir := range pluginDirectories {
 		manifestPath := filepath.Join(dir, manifestName)


### PR DESCRIPTION
<!-- 
Hi there, have an early THANK YOU for your contribution!
k3d is a community-driven project, so we really highly appreciate any support.
Please make sure, you've read our Code of Conduct and the Contributing Guidelines :)
- Code of Conduct: https://github.com/k3d-io/k3d/blob/main/CODE_OF_CONDUCT.md
- Contributing Guidelines: https://github.com/k3d-io/k3d/blob/main/CONTRIBUTING.md
-->

# What

Add plugin system in k3d. This allows expanding k3d functionalities by loading third party scripts/programs.

# Why

This feature has been requested in #304 and backed by a discussion (#741)

# Implications

This feature extends `k3d` command by dynamically adding subcommands loaded from plugins located in `.k3d/plugins`.

<!-- Get recognized using our all-contributors bot: https://github.com/k3d-io/k3d/blob/main/CONTRIBUTING.md#get-recognized -->
