### PR TITLE
Fix deleting of cluster by config file

### DIFF
--- a/cmd/cluster/clusterDelete.go
+++ b/cmd/cluster/clusterDelete.go
@@ -137,9 +137,9 @@ func parseDeleteClusterCmd(cmd *cobra.Command, args []string) []*k3d.Cluster {
 			l.Log().Fatalln("failed to delete cluster via config file: no name in config file")
 		}
 
-		c, err := client.ClusterGet(cmd.Context(), runtimes.SelectedRuntime, &k3d.Cluster{Name: clusterDeleteCfgViper.GetString("name")})
+		c, err := client.ClusterGet(cmd.Context(), runtimes.SelectedRuntime, &k3d.Cluster{Name: cfg.Name})
 		if errors.Is(err, client.ClusterGetNoNodesFoundError) {
-			l.Log().Infof("No nodes found for cluster '%s', nothing to delete.", clusterDeleteCfgViper.GetString("name"))
+			l.Log().Infof("No nodes found for cluster '%s', nothing to delete.", cfg.Name)
 			return nil
 		}
 


### PR DESCRIPTION
<!-- 
Hi there, have an early THANK YOU for your contribution!
k3d is a community-driven project, so we really highly appreciate any support.
Please make sure, you've read our Code of Conduct and the Contributing Guidelines :)
- Code of Conduct: https://github.com/k3d-io/k3d/blob/main/CODE_OF_CONDUCT.md
- Contributing Guidelines: https://github.com/k3d-io/k3d/blob/main/CONTRIBUTING.md
-->

# What

<!-- What does this PR do or change? -->
With the change from using `name` to `metadata.name`, the delete by config file didn't work. This fixes that bug

# Why

<!-- Link issues, discussions, etc. or just explain why you're creating this PR -->
Fixes #1041

# Implications

<!--
Does this change existing behavior? If so, does it affect the CLI (cmd/) only or does it also/only change some internals of the Go module (pkg/)?
Especially mention breaking changes here!
-->
No change to functionality, except a bugfix

<!-- Get recognized using our all-contributors bot: https://github.com/k3d-io/k3d/blob/main/CONTRIBUTING.md#get-recognized -->
