### PR TITLE
feat: allow set image in simpleConfig.Registries.Create

### DIFF
--- a/pkg/config/transform.go
+++ b/pkg/config/transform.go
@@ -314,10 +314,15 @@ func TransformSimpleToClusterConfig(ctx context.Context, runtime runtimes.Runtim
 			regName = simpleConfig.Registries.Create.Name
 		}
 
+		image := fmt.Sprintf("%s:%s", k3d.DefaultRegistryImageRepo, k3d.DefaultRegistryImageTag)
+		if simpleConfig.Registries.Create.Image != "" {
+			image = simpleConfig.Registries.Create.Image
+		}
+
 		clusterCreateOpts.Registries.Create = &k3d.Registry{
 			ClusterRef:   newCluster.Name,
 			Host:         regName,
-			Image:        fmt.Sprintf("%s:%s", k3d.DefaultRegistryImageRepo, k3d.DefaultRegistryImageTag),
+			Image:        image,
 			ExposureOpts: *regPort,
 		}
 	}

--- a/pkg/config/v1alpha4/schema.json
+++ b/pkg/config/v1alpha4/schema.json
@@ -294,6 +294,13 @@
                 "2345"
               ],
               "default": "random"
+            },
+            "image": {
+              "type": "string",
+              "examples": [
+                "myregistry/registry:2"
+              ],
+              "default": "docker.io/library/registry:2"
             }
           },
           "additionalProperties": false

--- a/pkg/config/v1alpha4/types.go
+++ b/pkg/config/v1alpha4/types.go
@@ -85,6 +85,7 @@ type SimpleConfigRegistryCreateConfig struct {
 	Name     string `mapstructure:"name" yaml:"name,omitempty" json:"name,omitempty"`
 	Host     string `mapstructure:"host" yaml:"host,omitempty" json:"host,omitempty"`
 	HostPort string `mapstructure:"hostPort" yaml:"hostPort,omitempty" json:"hostPort,omitempty"`
+	Image    string `mapstructure:"image" yaml:"image,omitempty" json:"image,omitempty"`
 }
 
 // SimpleConfigOptionsKubeconfig describes the set of options referring to the kubeconfig during cluster creation.


### PR DESCRIPTION
<!-- 
Hi there, have an early THANK YOU for your contribution!
k3d is a community-driven project, so we really highly appreciate any support.
Please make sure, you've read our Code of Conduct and the Contributing Guidelines :)
- Code of Conduct: https://github.com/k3d-io/k3d/blob/main/CODE_OF_CONDUCT.md
- Contributing Guidelines: https://github.com/k3d-io/k3d/blob/main/CONTRIBUTING.md
-->

# What

<!-- What does this PR do or change? -->

this PR adds a Image config to simpleConfig.Registry.Create, so we can specify a alternative registry other than "docker.io/library/registry:2"

# Why

<!-- Link issues, discussions, etc. or just explain why you're creating this PR -->

we're running k3d in our CI infrastructure, but unfortunately runs into an error on rate limitted by docker.io registry:

<img width="1342" alt="Screen Shot 2022-04-22 at 10 40 37 AM" src="https://user-images.githubusercontent.com/129800/164585607-3d7e1e0c-90ca-4f27-aaff-519eff7d6125.png">

we can specify a custom `--image` in the `k3d registry create` subcommand which allowing us switch a private registry to avoid this problem, but we do not have a related image config in the `config.yaml` in `k3d cluster create` yet, in our CI config, this config.yaml plays an all-in-one config for k3d, it'd be convenient to allow us config the registry image in this config file.

# Implications

<!--
Does this change existing behavior? If so, does it affect the CLI (cmd/) only or does it also/only change some internals of the Go module (pkg/)?
Especially mention breaking changes here!
-->

this PR do not change the existed behavior, if the image field is empty, it falls back to the default registry image.

<!-- Get recognized using our all-contributors bot: https://github.com/k3d-io/k3d/blob/main/CONTRIBUTING.md#get-recognized -->
