### PR TITLE
docs: fix defualts-networking href

### DIFF
--- a/docs/design/defaults.md
+++ b/docs/design/defaults.md
@@ -57,4 +57,4 @@ The loadbalancer can partly be configured using k3d-defined settings.
 
 ## Networking
 
-- [by default, k3d creates a new (docker) network for every cluster](./networking)
+- [by default, k3d creates a new (docker) network for every cluster](./networking.md)


### PR DESCRIPTION
<!-- 
Hi there, have an early THANK YOU for your contribution!
k3d is a community-driven project, so we really highly appreciate any support.
Please make sure, you've read our Code of Conduct and the Contributing Guidelines :)
- Code of Conduct: https://github.com/k3d-io/k3d/blob/main/CODE_OF_CONDUCT.md
- Contributing Guidelines: https://github.com/k3d-io/k3d/blob/main/CONTRIBUTING.md
-->

# What & Why

<!-- What does this PR do or change? -->
In the document default section, the link to the networking page was not working
https://k3d.io/v5.4.1/design/defaults/#networking

This PR fixes that


<!-- Link issues, discussions, etc. or just explain why you're creating this PR -->



<!--
Does this change existing behavior? If so, does it affect the CLI (cmd/) only or does it also/only change some internals of the Go module (pkg/)?
Especially mention breaking changes here!
-->

<!-- Get recognized using our all-contributors bot: https://github.com/k3d-io/k3d/blob/main/CONTRIBUTING.md#get-recognized -->
