### PR TITLE
Add support to run with podman in rootless mode using cgroups v2

### DIFF
--- a/docs/usage/advanced/podman.md
+++ b/docs/usage/advanced/podman.md
@@ -66,7 +66,7 @@ EOF
 systemctl daemon-reload
 ```
 
-Reference: https://rootlesscontaine.rs/getting-started/common/cgroup2/#enabling-cpu-cpuset-and-io-delegation
+Reference: [https://rootlesscontaine.rs/getting-started/common/cgroup2/#enabling-cpu-cpuset-and-io-delegation](https://rootlesscontaine.rs/getting-started/common/cgroup2/#enabling-cpu-cpuset-and-io-delegation)
 
 ### Using remote Podman
 

--- a/docs/usage/advanced/podman.md
+++ b/docs/usage/advanced/podman.md
@@ -48,6 +48,26 @@ export DOCKER_SOCK=$XDG_RUNTIME_DIR/podman/podman.sock
 k3d cluster create
 ```
 
+#### Using cgroup (v2)
+
+By default, a non-root user can only get memory controller and pids controller to be delegated.
+
+To run properly we need to enable CPU, CPUSET, and I/O delegation
+
+!!! note "Make sure you're running cgroup v2"
+    If `/sys/fs/cgroup/cgroup.controllers` is present on your system, you are using v2, otherwise you are using v1.
+
+```bash
+mkdir -p /etc/systemd/system/user@.service.d
+cat > /etc/systemd/system/user@.service.d/delegate.conf <<EOF
+[Service]
+Delegate=cpu cpuset io memory pids
+EOF
+systemctl daemon-reload
+```
+
+Reference: https://rootlesscontaine.rs/getting-started/common/cgroup2/#enabling-cpu-cpuset-and-io-delegation
+
 ### Using remote Podman
 
 [Start Podman on the remote host](https://github.com/containers/podman/blob/main/docs/tutorials/remote_client.md), and then set `DOCKER_HOST` when running k3d:
@@ -77,3 +97,4 @@ k3d cluster create --registry-use mycluster-registry mycluster
 
 !!! note "Missing cpuset cgroup controller"
     If you experince an error regarding missing cpuset cgroup controller, ensure the user unit `xdg-document-portal.service` is disabled by running `systemctl --user stop xdg-document-portal.service`. See [this issue](https://github.com/systemd/systemd/issues/18293#issuecomment-831397578)
+


### PR DESCRIPTION
<!-- 
Hi there, have an early THANK YOU for your contribution!
k3d is a community-driven project, so we really highly appreciate any support.
Please make sure, you've read our Code of Conduct and the Contributing Guidelines :)
- Code of Conduct: https://github.com/k3d-io/k3d/blob/main/CODE_OF_CONDUCT.md
- Contributing Guidelines: https://github.com/k3d-io/k3d/blob/main/CONTRIBUTING.md
-->

# What

Fix running k3d with podman and cgroups (v2)

# Why

* By running podman in rootless mode, `k3d`/`k3s` requires extra delegation in order to work (cpu, cpuset and I/O delegations), added the steps to the doc. Some errors like `failed to find cpu cgroup (v2)` would happened on cgroup v2 and cpu delegation not enabled (https://github.com/k3d-io/k3d/issues/585)
* Podman is API compatible with docker, however there is a slightly difference on network retrieval of IP address. One uses only CIDR notation (127.0.0.1/32) while the other, for unique IP address use the literal notation (127.0.0.1). Create a wrapper function to extract the value instead of throwing an error.

  The following happened before the fix (`netaddr.ParseIPPrefix("11.89.1.4"): no '/' `)

  ```shell
  ❯ k3d cluster create testing
  INFO[0000] Prep: Network                                
  INFO[0000] Created network 'k3d-testing'                
  INFO[0000] Created image volume k3d-testing-images      
  INFO[0000] Starting new tools node...                   
  INFO[0000] Starting Node 'k3d-testing-tools'            
  INFO[0001] Creating node 'k3d-testing-server-0'         
  INFO[0001] Creating LoadBalancer 'k3d-testing-serverlb' 
  INFO[0001] Using the k3d-tools node to gather environment information 
  INFO[0002] HostIP: using network gateway 10.89.1.1 address 
  INFO[0002] Starting cluster 'testing'                   
  INFO[0002] Starting servers...                          
  INFO[0002] Starting Node 'k3d-testing-server-0'         
  INFO[0007] All agents already running.                  
  INFO[0007] Starting helpers...                          
  INFO[0007] Starting Node 'k3d-testing-serverlb'         
  ERRO[0015] Failed Cluster Start: error during post-start cluster preparation: failed to get cluster network k3d-testing to inject host records into CoreDNS: failed to parse IP of container k3d-testing: netaddr.ParseIPPrefix("11.89.1.4"): no '/' 
  ERRO[0015] Failed to create cluster >>> Rolling Back    
  INFO[0015] Deleting cluster 'testing'                   
  INFO[0016] Deleting cluster network 'k3d-testing'       
  INFO[0016] Deleting 3 attached volumes...               
  WARN[0016] Failed to delete volume 'k3d-testing-images' of cluster 'testing': docker failed to delete volume 'k3d-k3s-default-images': Error response from daemon: volume k3d-k3s-default-images is being used by the following container(s): 5fc21a07d4189a0a93dd3a65142f1f5889e1788ca0076347e4d80aed05e9dd9d, 714544cc5de7ae3ae273f6c3c1285099d8509e4a8c3fe27d7c0ac59ff38537de: volume is being used -> Try to delete it manually 
  WARN[0016] Failed to delete volume 'k3d-testing-images' of cluster 'testing': failed to find volume 'k3d-testing-images': Error: No such volume: k3d-testing-images -> Try to delete it manually 
  FATA[0016] Cluster creation FAILED, all changes have been rolled back! 
  ```

# Implications

N/A

<!--
Does this change existing behavior? If so, does it affect the CLI (cmd/) only or does it also/only change some internals of the Go module (pkg/)?
Especially mention breaking changes here!
-->

<!-- Get recognized using our all-contributors bot: https://github.com/k3d-io/k3d/blob/main/CONTRIBUTING.md#get-recognized -->
