### PR TITLE
Fix default config template for v1alpha4

### DIFF
--- a/pkg/config/v1alpha4/types.go
+++ b/pkg/config/v1alpha4/types.go
@@ -43,7 +43,8 @@ var JSONSchema string
 const DefaultConfigTpl = `---
 apiVersion: k3d.io/v1alpha4
 kind: Simple
-name: %s
+metadata:
+  name: %s
 servers: 1
 agents: 0
 image: %s


### PR DESCRIPTION
Hello everyone, the command `k3d config init` creates a faulty config for cluster creation. This commit moves the `name`   into `metadata.name` for the `k3d.io/v1alpha4 Simple` format as per https://github.com/k3d-io/k3d/pull/945.
