### PR TITLE
fix: prefix stripping in image import

### DIFF
--- a/pkg/client/tools.go
+++ b/pkg/client/tools.go
@@ -310,12 +310,17 @@ func isFile(image string) bool {
 }
 
 func dockerSpecialImageNameEqual(requestedImageName string, runtimeImageName string) bool {
-	if strings.HasPrefix(requestedImageName, "docker.io/") {
-		return dockerSpecialImageNameEqual(strings.TrimPrefix(requestedImageName, "docker.io/"), runtimeImageName)
+	prefixes := []string{
+		"docker.io/library/",
+		"docker.io/",
+		"library/",
 	}
 
-	if strings.HasPrefix(requestedImageName, "library/") {
-		return imageNamesEqual(strings.TrimPrefix(requestedImageName, "library/"), runtimeImageName)
+	for _, prefix := range prefixes {
+		if strings.HasPrefix(requestedImageName, prefix) {
+			return imageNamesEqual(strings.TrimPrefix(requestedImageName, prefix), runtimeImageName)
+		}
+
 	}
 
 	return false

--- a/pkg/client/tools_test.go
+++ b/pkg/client/tools_test.go
@@ -46,6 +46,7 @@ func Test_findRuntimeImage(T *testing.T) {
 		"registry:1234/one/two:latest",
 		"registry:1234/one/two/three/four:version",
 		"registry:1234/one/two/three/four:latest",
+		"one/two:latest",
 	}
 
 	tests := map[string]struct {
@@ -142,6 +143,16 @@ func Test_findRuntimeImage(T *testing.T) {
 			expectedImageName:       "busybox:version",
 			expectedFound:           true,
 			givenRequestedImageName: "docker.io/library/busybox:version",
+		},
+		"docker.io is used as registry": {
+			expectedImageName:       "one/two:latest",
+			expectedFound:           true,
+			givenRequestedImageName: "docker.io/one/two:latest",
+		},
+		"docker.io is used as registry, no version tag": {
+			expectedImageName:       "one/two:latest",
+			expectedFound:           true,
+			givenRequestedImageName: "docker.io/one/two",
 		},
 		"unknown image": {
 			expectedFound:           false,


### PR DESCRIPTION
# What

When importing images, properly handle docker.io/ prefix, to match description of the command.

# Why

Right now this does not work as advertised in the description.

```
❯ k3d image import --cluster demo docker.io/bitnami/kubectl:latest
INFO[0000] Importing image(s) into cluster 'demo'
WARN[0000] Image 'docker.io/bitnami/kubectl:latest' is not a file and couldn't be found in the container runtime
ERRO[0000] Failed to import image(s) into cluster 'demo': no valid images specified
WARN[0000] At least one error occured while trying to import the image(s) into the selected cluster(s)

❯ docker images | grep kubectl
bitnami/kubectl            latest          3366d08f95eb   39 hours ago   223MB
```

# Implications

This change affects how CLI works. It makes the actual behaviour consistent with the description.

