### PR TITLE
add kubeconfig-path

### DIFF
--- a/cmd/cluster/clusterCreate.go
+++ b/cmd/cluster/clusterCreate.go
@@ -184,7 +184,7 @@ func NewCmdClusterCreate() *cobra.Command {
 
 			if clusterConfig.KubeconfigOpts.UpdateDefaultKubeconfig {
 				l.Log().Debugf("Updating default kubeconfig with a new context for cluster %s", clusterConfig.Cluster.Name)
-				if _, err := k3dCluster.KubeconfigGetWrite(cmd.Context(), runtimes.SelectedRuntime, &clusterConfig.Cluster, "", &k3dCluster.WriteKubeConfigOptions{UpdateExisting: true, OverwriteExisting: false, UpdateCurrentContext: simpleCfg.Options.KubeconfigOptions.SwitchCurrentContext}); err != nil {
+				if _, err := k3dCluster.KubeconfigGetWrite(cmd.Context(), runtimes.SelectedRuntime, &clusterConfig.Cluster, clusterConfig.KubeconfigOpts.KubeConfigPath, &k3dCluster.WriteKubeConfigOptions{UpdateExisting: true, OverwriteExisting: false, UpdateCurrentContext: simpleCfg.Options.KubeconfigOptions.SwitchCurrentContext}); err != nil {
 					l.Log().Warningln(err)
 				}
 			}
@@ -296,6 +296,9 @@ func NewCmdClusterCreate() *cobra.Command {
 
 	cmd.Flags().Duration("timeout", 0*time.Second, "Rollback changes if cluster couldn't be created in specified duration.")
 	_ = cfgViper.BindPFlag("options.k3d.timeout", cmd.Flags().Lookup("timeout"))
+
+	cmd.Flags().String("kubeconfig-path", "", "Specify path where kube config will be saved. By default this value is loaded from KUBECONFIG env")
+	_ = cfgViper.BindPFlag("options.kubeconfig.kubeconfigpath", cmd.Flags().Lookup("kubeconfig-path"))
 
 	cmd.Flags().Bool("kubeconfig-update-default", true, "Directly update the default kubeconfig with the new cluster's context")
 	_ = cfgViper.BindPFlag("options.kubeconfig.updatedefaultkubeconfig", cmd.Flags().Lookup("kubeconfig-update-default"))

--- a/pkg/config/v1alpha4/types.go
+++ b/pkg/config/v1alpha4/types.go
@@ -36,6 +36,7 @@ import (
 const ApiVersion = "k3d.io/v1alpha4"
 
 // JSONSchema describes the schema used to validate config files
+//
 //go:embed schema.json
 var JSONSchema string
 
@@ -93,8 +94,9 @@ type SimpleConfigRegistryCreateConfig struct {
 
 // SimpleConfigOptionsKubeconfig describes the set of options referring to the kubeconfig during cluster creation.
 type SimpleConfigOptionsKubeconfig struct {
-	UpdateDefaultKubeconfig bool `mapstructure:"updateDefaultKubeconfig" json:"updateDefaultKubeconfig,omitempty"` // default: true
-	SwitchCurrentContext    bool `mapstructure:"switchCurrentContext" json:"switchCurrentContext,omitempty"`       //nolint:lll    // default: true
+	KubeConfigPath          string `mapstructure:"kubeConfigPath" json:"kubeConfigPath,omitempty"`                   // default: ""
+	UpdateDefaultKubeconfig bool   `mapstructure:"updateDefaultKubeconfig" json:"updateDefaultKubeconfig,omitempty"` // default: true
+	SwitchCurrentContext    bool   `mapstructure:"switchCurrentContext" json:"switchCurrentContext,omitempty"`       //nolint:lll    // default: true
 }
 
 type SimpleConfigOptions struct {


### PR DESCRIPTION
# What
Expose new flag `kubeconfig-path` to `cluster create` command.

# Why
https://github.com/k3d-io/k3d/issues/1160

# Implications
I am not sure but probably that needs new version of https://github.com/k3d-io/k3d/tree/main/pkg/config ? Like [v1alpha5](https://github.com/k3d-io/k3d/tree/main/pkg/config/v1alpha5) ?
