### PR TITLE
fix: indentation for CoreDNS doc

### DIFF
--- a/docs/usage/k3s.md
+++ b/docs/usage/k3s.md
@@ -12,7 +12,7 @@ K3s ships with lots of built-in features and services, some of which may only be
 
 > Cluster DNS service
 
-## Resources
+### Resources
 
 - Manifest embedded in K3s: <https://github.com/k3s-io/k3s/blob/master/manifests/coredns.yaml>
   - Note: it includes template variables (like `%{CLUSTER_DOMAIN}%`) that will be replaced by K3s before writing the file to the filesystem


### PR DESCRIPTION
<!-- 
Hi there, have an early THANK YOU for your contribution!
k3d is a community-driven project, so we really highly appreciate any support.
Please make sure, you've read our Code of Conduct and the Contributing Guidelines :)
- Code of Conduct: https://github.com/k3d-io/k3d/blob/main/CODE_OF_CONDUCT.md
- Contributing Guidelines: https://github.com/k3d-io/k3d/blob/main/CONTRIBUTING.md
-->

# What

Fixed indentation of the CoreDNS "Resources" section.

# Why

As is, It looks like the CoreDNS section doesn't have any content.

# Implications

None. Doc only.

<!-- Get recognized using our all-contributors bot: https://github.com/k3d-io/k3d/blob/main/CONTRIBUTING.md#get-recognized -->
