### PR TITLE
fix: install script on windows

### DIFF
--- a/.github/workflows/test-install-osmatrix.yaml
+++ b/.github/workflows/test-install-osmatrix.yaml
@@ -1,0 +1,30 @@
+name: Test install.sh
+
+on:
+  pull_request:
+    paths:
+      - 'install.sh'
+  push:
+    branches:
+      - 'main'
+      - 'pr-*'
+
+jobs:
+  test-install-script:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run install.sh on ${{ matrix.os }}
+        shell: bash
+        # just run install.sh b/c github can throttle itself based on egress limits and gets 503 sometimes
+        run: |
+          echo "Simulating: curl -s https://raw.githubusercontent.com/$GITHUB_REPOSITORY/$GITHUB_REF_NAME/install.sh | bash"
+          ./install.sh
+          k3d version
+      - name: Create cluster
+        if: matrix.os == 'ubuntu-latest' # mac and windows Github runners can't use docker
+        run: k3d cluster create demo

--- a/install.sh
+++ b/install.sh
@@ -30,6 +30,11 @@ initOS() {
     mingw*) 
       OS="windows"
       USE_SUDO="false"
+      if [[ ! -d "$K3D_INSTALL_DIR" ]]; then
+        # mingw bash that ships with Git for Windows doesn't have /usr/local/bin but ~/bin is first entry in the path
+        mkdir -p ~/bin
+        K3D_INSTALL_DIR=~/bin
+      fi
       ;;
   esac
 }

--- a/install.sh
+++ b/install.sh
@@ -27,7 +27,10 @@ initOS() {
 
   case "$OS" in
     # Minimalist GNU for Windows
-    mingw*) OS='windows';;
+    mingw*) 
+      OS="windows"
+      USE_SUDO="false"
+      ;;
   esac
 }
 
@@ -107,6 +110,9 @@ checkLatestVersion() {
 downloadFile() {
   K3D_DIST="k3d-$OS-$ARCH"
   DOWNLOAD_URL="$REPO_URL/releases/download/$TAG/$K3D_DIST"
+  if [[ "$OS" == "windows" ]]; then
+    DOWNLOAD_URL=${DOWNLOAD_URL}.exe
+  fi
   K3D_TMP_ROOT="$(mktemp -dt k3d-binary-XXXXXX)"
   K3D_TMP_FILE="$K3D_TMP_ROOT/$K3D_DIST"
   if type "curl" > /dev/null; then


### PR DESCRIPTION
# What

Fix install.sh script for windows (mingw/msys2 bash).

# Why

The install script wasn't working on windows b/c the released binary for windows has a .exe extension on it which made the script error with a 404. Also, the USE_SUDO variable should be set to false by default on windows (otherwise piping script to bash won't work). 

# Implications

An alternative fix would be to change the releases to not include the .exe extension on the windows binary but maybe that was done for use outside of mingw where the install.sh script wouldn't be used. The install script still saves k3d to /usr/local/bin/k3d without the .exe extension and it works without the .exe extension (in msys2/mingw). It would work the same way if it was saved as k3d.exe.

