### PR TITLE
fix: improved error handling when update.k3s.io returns a 5XX or invalid response

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -40,6 +40,11 @@ var HelperVersionOverride string
 // K3sVersion should contain the latest version tag of k3s (hardcoded at build time)
 var K3sVersion = "v1.21.7-k3s1"
 
+type httpClient struct {
+	client  *http.Client
+	baseURL string
+}
+
 // GetVersion returns the version for cli, it gets it from "git describe --tags" or returns "dev" when doing simple go build
 func GetVersion() string {
 	if len(Version) == 0 {
@@ -51,7 +56,7 @@ func GetVersion() string {
 // GetK3sVersion returns the version string for K3s
 func GetK3sVersion(channel string) (string, error) {
 	if channel != "" {
-		version, err := fetchLatestK3sVersion(channel)
+		version, err := newHttpClient(k3s.K3sChannelServerURL).fetchLatestK3sVersion(channel)
 		if err != nil {
 			return "", fmt.Errorf("error getting K3s version for channel %s: %w", channel, err)
 		}
@@ -61,13 +66,27 @@ func GetK3sVersion(channel string) (string, error) {
 }
 
 // fetchLatestK3sVersion tries to fetch the latest version of k3s from DockerHub
-func fetchLatestK3sVersion(channel string) (string, error) {
-
-	resp, err := http.Get(k3s.K3sChannelServerURL)
+func (c *httpClient) fetchLatestK3sVersion(channel string) (string, error) {
+	request, err := http.NewRequest(http.MethodGet, c.baseURL, nil)
 	if err != nil {
 		return "", err
 	}
-	defer resp.Body.Close()
+
+	resp, err := c.client.Do(request)
+	if err != nil {
+		return "", err
+	}
+
+	defer func(Body io.ReadCloser) {
+		err = Body.Close()
+		if err != nil {
+
+		}
+	}(resp.Body)
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf(fmt.Sprintf("call made to '%s' failed with status code '%d'", c.baseURL, resp.StatusCode))
+	}
 
 	out := k3s.ChannelServerResponse{}
 
@@ -76,7 +95,7 @@ func fetchLatestK3sVersion(channel string) (string, error) {
 		return "", fmt.Errorf("error reading channelserver response body: %w", err)
 	}
 
-	if err := json.Unmarshal(body, &out); err != nil {
+	if err = json.Unmarshal(body, &out); err != nil {
 		return "", fmt.Errorf("error unmarshalling channelserver response: %w", err)
 	}
 
@@ -86,6 +105,13 @@ func fetchLatestK3sVersion(channel string) (string, error) {
 		}
 	}
 
-	return "", fmt.Errorf("no latest version found for channel %s (%s)", channel, k3s.K3sChannelServerURL)
+	return "", fmt.Errorf("no latest version found for channel %s (%s)", channel, c.baseURL)
 
+}
+
+func newHttpClient(baseURL string) *httpClient {
+	return &httpClient{
+		client:  &http.Client{},
+		baseURL: baseURL,
+	}
 }

--- a/version/version_test.go
+++ b/version/version_test.go
@@ -143,7 +143,7 @@ func TestFetchLatestK3sVersion(t *testing.T) {
 			errorString:        "call made to '%s' failed with status code '500'",
 		},
 		{
-			description:   "should error out while fetching the latest k3s version as response returned in non non understandable",
+			description:   "should error out while fetching the latest k3s version as response returned in not understandable",
 			channel:       "v1.25",
 			expected:      "",
 			mockServer:    mockServer([]byte(`{"data": [`), http.StatusOK),

--- a/version/version_test.go
+++ b/version/version_test.go
@@ -22,6 +22,10 @@ THE SOFTWARE.
 package version
 
 import (
+	"fmt"
+	"log"
+	"net/http"
+	"net/http/httptest"
 	"regexp"
 	"testing"
 )
@@ -37,4 +41,150 @@ func TestGetK3sVersion(t *testing.T) {
 	if !latestRegexp.Match([]byte(v)) {
 		t.Fatalf("found version %s (searched: %s) does not match respective latest regexp `%s`", v, searchVersion, latestRegexp.String())
 	}
+}
+
+func Test_fetchLatestK3sVersion(t *testing.T) {
+	type errorTestCases struct {
+		description        string
+		channel            string
+		mockServer         *httptest.Server
+		expected           string
+		expectedError      bool
+		constructErrString bool
+		errorString        string
+	}
+	tests := []errorTestCases{
+		{
+			description: "should be able to fetch the latest k3s version successfully",
+			channel:     "v1.24",
+			expected:    "v1.24.6-k3s1",
+			mockServer: mockServer([]byte(`{
+  "data": [
+    {
+      "id": "stable",
+      "type": "channel",
+      "links": {
+        "self": "https://update.k3s.io/v1-release/channels/stable"
+      },
+      "name": "v1.24",
+      "latest": "v1.24.6+k3s1"
+    },
+    {
+      "id": "latest",
+      "type": "channel",
+      "links": {
+        "self": "https://update.k3s.io/v1-release/channels/latest"
+      },
+      "name": "latest",
+      "latest": "v1.25.2+k3s1",
+      "latestRegexp": ".*",
+      "excludeRegexp": "^[^+]+-"
+    }
+  ]
+}`), http.StatusOK),
+		},
+		{
+			description: "should be able to fetch the latest k3s version successfully",
+			channel:     "v1.25",
+			expected:    "v1.25.2-k3s1",
+			mockServer: mockServer([]byte(`{
+  "data": [
+    {
+      "id": "stable",
+      "type": "channel",
+      "links": {
+        "self": "https://update.k3s.io/v1-release/channels/stable"
+      },
+      "name": "stable",
+      "latest": "v1.24.6+k3s1"
+    },
+    {
+      "id": "latest",
+      "type": "channel",
+      "links": {
+        "self": "https://update.k3s.io/v1-release/channels/latest"
+      },
+      "name": "v1.25",
+      "latest": "v1.25.2+k3s1",
+      "latestRegexp": ".*",
+      "excludeRegexp": "^[^+]+-"
+    }
+  ]
+}`), http.StatusOK),
+		},
+		{
+			description:        "should error out as no latest version found for selected channel",
+			channel:            "v1.25",
+			expected:           "",
+			expectedError:      true,
+			errorString:        "no latest version found for channel v1.25 (%s)",
+			constructErrString: true,
+			mockServer: mockServer([]byte(`{
+  "data": [
+    {
+      "id": "stable",
+      "type": "channel",
+      "links": {
+        "self": "https://update.k3s.io/v1-release/channels/stable"
+      },
+      "name": "stable",
+      "latest": "v1.24.6+k3s1"
+    }
+  ]
+}`), http.StatusOK),
+		},
+		{
+			description:        "should error out while fetching the latest k3s version as call made to URL returned 500",
+			channel:            "v1.25",
+			expected:           "",
+			mockServer:         mockServer([]byte(``), http.StatusInternalServerError),
+			expectedError:      true,
+			constructErrString: true,
+			errorString:        "call made to '%s' failed with status code '500'",
+		},
+		{
+			description:   "should error out while fetching the latest k3s version as response returned in non non understandable",
+			channel:       "v1.25",
+			expected:      "",
+			mockServer:    mockServer([]byte(`{"data": [`), http.StatusOK),
+			expectedError: true,
+			errorString:   "error unmarshalling channelserver response: unexpected end of JSON input",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.description, func(t *testing.T) {
+			client := httpClient{client: tt.mockServer.Client(), baseURL: tt.mockServer.URL}
+
+			defer tt.mockServer.Close()
+
+			got, err := client.fetchLatestK3sVersion(tt.channel)
+			if (err != nil) && (!tt.expectedError) {
+				t.Errorf("fetchLatestK3sVersion() error = %v, wantErr %v", err, tt.errorString)
+				return
+			}
+			if tt.expectedError {
+				errorString := tt.errorString
+				if tt.constructErrString {
+					errorString = fmt.Sprintf(tt.errorString, tt.mockServer.URL)
+				}
+				if err.Error() != errorString {
+					t.Errorf("expected error '%s', but got '%s'", errorString, err.Error())
+				}
+			}
+			if got != tt.expected {
+				t.Errorf("fetchLatestK3sVersion() got = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func mockServer(body []byte, statusCode int) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, req *http.Request) {
+		writer.WriteHeader(statusCode)
+		_, err := writer.Write(body)
+		if err != nil {
+			log.Fatalln(err)
+		}
+	}))
 }

--- a/version/version_test.go
+++ b/version/version_test.go
@@ -43,7 +43,7 @@ func TestGetK3sVersion(t *testing.T) {
 	}
 }
 
-func Test_fetchLatestK3sVersion(t *testing.T) {
+func TestFetchLatestK3sVersion(t *testing.T) {
 	type errorTestCases struct {
 		description        string
 		channel            string


### PR DESCRIPTION
# What
Better handling of http call made to update.k3s.io.
Update the way of handling the http client call for fetchLatestK3sVersion, to make it more testable.

# Why
#1129 

# Implications
This will check the http status code to the calls made to update.k3s.io, and handle it accordingly.