### PR TITLE
fix: logs error shadowing exec error

### DIFF
--- a/pkg/runtimes/docker/node.go
+++ b/pkg/runtimes/docker/node.go
@@ -352,9 +352,9 @@ func execInNode(ctx context.Context, node *k3d.Node, cmd []string, stdin io.Read
 	}
 	if err != nil {
 		if execConnection != nil && execConnection.Reader != nil {
-			logs, err := io.ReadAll(execConnection.Reader)
-			if err != nil {
-				return fmt.Errorf("failed to get logs from errored exec process in node '%s': %w", node.Name, err)
+			logs, logsErr := io.ReadAll(execConnection.Reader)
+			if logsErr != nil {
+				return fmt.Errorf("failed to get logs from errored exec process in node '%s': %w", node.Name, logsErr)
 			}
 			err = fmt.Errorf("%w: Logs from failed access process:\n%s", err, string(logs))
 		}


### PR DESCRIPTION



<!-- 
Hi there, have an early THANK YOU for your contribution!
k3d is a community-driven project, so we really highly appreciate any support.
Please make sure, you've read our Code of Conduct and the Contributing Guidelines :)
- Code of Conduct: https://github.com/k3d-io/k3d/blob/main/CODE_OF_CONDUCT.md
- Contributing Guidelines: https://github.com/k3d-io/k3d/blob/main/CONTRIBUTING.md
-->

# What
Rename an inner error to `logsError` to stop it shadowing the value of a higher scoped `err`.

# Why
The assignment from `io.ReadAll` was overwriting the value of the original error and stopping the logs of the failed exec from being printed.


# Implications

<!--
Does this change existing behavior? If so, does it affect the CLI (cmd/) only or does it also/only change some internals of the Go module (pkg/)?
Especially mention breaking changes here!
-->

fixes #1171

Now when `k3d image import` fails the logs from the failed command will be logged (this is intended behaviour):
```
$ ../k3d/bin/k3d image import -c local -m direct test.tar
INFO[0000] Importing image(s) into cluster 'local'      
INFO[0000] Importing images from 1 tarball(s)...        
INFO[0000] Importing images '[test.tar]' into node 'k3d-local-server-0'... 
ERRO[0001] Failed to import image(s) into cluster 'local': could not load image to cluster from stream test.tar: error loading image to cluster, first error: failed to import images in node 'k3d-local-server-0': Exec process in node 'k3d-local-server-0' failed with exit code '1': Logs from failed access process:
ctr: unrecognized image format 
WARN[0001] At least one error occured while trying to import the image(s) into the selected cluster(s)
```

<!-- Get recognized using our all-contributors bot: https://github.com/k3d-io/k3d/blob/main/CONTRIBUTING.md#get-recognized -->
