### PR TITLE
change: Use loadbalancer or any *active* server as K3S_URL

### DIFF
--- a/pkg/client/cluster.go
+++ b/pkg/client/cluster.go
@@ -397,6 +397,10 @@ ClusterCreatOpts:
 	 */
 
 	clusterCreateOpts.GlobalLabels[k3d.LabelClusterName] = cluster.Name
+	// Add serverlb url to be used as tls-san value
+	// This is used to avoid a fatal error on registering server nodes
+	// using loadbalancer
+	clusterCreateOpts.GlobalLabels[k3d.LabelServerLoadBalancer] = fmt.Sprintf("%s-%s-serverlb", k3d.DefaultObjectNamePrefix, cluster.Name)
 
 	// agent defaults (per cluster)
 	// connection url is always the name of the first server node (index 0) // TODO: change this to the server loadbalancer

--- a/pkg/client/cluster.go
+++ b/pkg/client/cluster.go
@@ -400,7 +400,11 @@ ClusterCreatOpts:
 	// Add serverlb url to be used as tls-san value
 	// This is used to avoid a fatal error on registering server nodes
 	// using loadbalancer
-	clusterCreateOpts.GlobalLabels[k3d.LabelServerLoadBalancer] = fmt.Sprintf("%s-%s-serverlb", k3d.DefaultObjectNamePrefix, cluster.Name)
+	if clusterCreateOpts.DisableLoadBalancer {
+		clusterCreateOpts.GlobalLabels[k3d.LabelServerLoadBalancer] = ""
+	} else {
+		clusterCreateOpts.GlobalLabels[k3d.LabelServerLoadBalancer] = fmt.Sprintf("%s-%s-serverlb", k3d.DefaultObjectNamePrefix, cluster.Name)
+	}
 
 	// agent defaults (per cluster)
 	// connection url is always the name of the first server node (index 0) // TODO: change this to the server loadbalancer

--- a/pkg/client/node.go
+++ b/pkg/client/node.go
@@ -726,6 +726,11 @@ func checkK3SURLIsActive(nodes []*k3d.Node, k3sURL string) bool {
 	// extract the node name
 	re := regexp.MustCompile("K3S_URL=https?://([a-zA-Z0-9_.-]+)")
 	match := re.FindStringSubmatch(k3sURL)
+
+	if match == nil {
+		return false
+	}
+
 	for _, node := range nodes {
 		if node.Name == match[1] {
 			return true

--- a/pkg/client/node.go
+++ b/pkg/client/node.go
@@ -678,7 +678,7 @@ func NodeDelete(ctx context.Context, runtime runtimes.Runtime, node *k3d.Node, o
 		}
 
 		// if it's a server node, then update the loadbalancer configuration
-		if node.Role == k3d.ServerRole {
+		if node.Role == k3d.ServerRole && cluster.ServerLoadBalancer != nil {
 			if err := UpdateLoadbalancerConfig(ctx, runtime, cluster); err != nil {
 				if !errors.Is(err, ErrLBConfigHostNotFound) {
 					return fmt.Errorf("failed to update cluster loadbalancer: %w", err)

--- a/pkg/client/node.go
+++ b/pkg/client/node.go
@@ -713,7 +713,10 @@ func patchServerSpec(node *k3d.Node, runtime runtimes.Runtime) error {
 	node.RuntimeLabels[k3d.LabelServerAPIPort] = node.ServerOpts.KubeAPI.Binding.HostPort
 
 	node.Args = append(node.Args, "--tls-san", node.RuntimeLabels[k3d.LabelServerAPIHost]) // add TLS SAN for non default host name
-	node.Args = append(node.Args, "--tls-san", node.RuntimeLabels[k3d.LabelServerLoadBalancer]) // add TLS SAN for server loadbalancer
+	if node.RuntimeLabels[k3d.LabelServerLoadBalancer] != "" {
+		// add TLS SAN for server loadbalancer
+		node.Args = append(node.Args, "--tls-san", node.RuntimeLabels[k3d.LabelServerLoadBalancer])
+	}
 
 	return nil
 }

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -91,6 +91,7 @@ const (
 	LabelServerAPIHost           string = "k3d.server.api.host"
 	LabelServerAPIHostIP         string = "k3d.server.api.hostIP"
 	LabelServerIsInit            string = "k3d.server.init"
+	LabelServerLoadBalancer      string = "k3d.server.loadbalancer"
 	LabelRegistryHost            string = "k3d.registry.host"
 	LabelRegistryHostIP          string = "k3d.registry.hostIP"
 	LabelRegistryPortExternal    string = "k3s.registry.port.external"

--- a/tests/local_test_registration_using_server_lb.sh
+++ b/tests/local_test_registration_using_server_lb.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+CURR_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+[ -d "$CURR_DIR" ] || { echo "FATAL: no current dir (maybe running in zsh?)";  exit 1; }
+
+# shellcheck source=./common.sh
+source "$CURR_DIR/common.sh"
+
+export CURRENT_STAGE="local | registration_using_server_lb"
+
+clean_up() {
+  info "Cleaning up"
+  $BIN cluster delete $CLUSTER_NAME > /dev/null || true
+}
+
+check_k3s_url() {
+  node=$1
+  expected_url=$2
+  curr_url=$(docker inspect $node | grep K3S_URL | awk -F"=" '{print $2}' | sed 's/",//')
+
+  if [ "$curr_url" != "$expected_url" ]; then
+    failed "Default K3S URL mismatch expected: '${expected_url}' got: ${curr_url}"
+  else
+    passed "$curr_url matches the expected: '${expected_url}'"
+  fi
+}
+
+run() {
+  cmd=$1
+  eval "${cmd} > /dev/null"
+}
+
+# Constants for tests
+BIN=~/code/k3d/bin/k3d
+CLUSTER_NAME=test-lb-registration
+K3S_URL_DEFAULT="https://k3d-${CLUSTER_NAME}-server-0:6443"
+K3S_URL_LB="https://k3d-${CLUSTER_NAME}-serverlb:6443"
+
+clean_up
+info "Starting a multi server cluster"
+run "$BIN cluster create $CLUSTER_NAME -s 3"
+
+info "Adding an agent and checking its K3S_URL"
+run "$BIN node create -c $CLUSTER_NAME testagent"
+check_k3s_url k3d-testagent-0 $K3S_URL_DEFAULT
+run "$BIN node delete k3d-testagent-0"
+
+info "Deleting server-0"
+run "$BIN node delete k3d-${CLUSTER_NAME}-server-0"
+run "kubectl delete node k3d-${CLUSTER_NAME}-server-0"
+
+info "Adding a new agent to check the new K3S_URL"
+run "$BIN node create -c $CLUSTER_NAME testagent1"
+check_k3s_url k3d-testagent1-0 $K3S_URL_LB
+run "$BIN node delete k3d-testagent1-0"
+
+info "Adding a new server to check K3S_URL"
+run "$BIN node create -c $CLUSTER_NAME testserver --role server"
+check_k3s_url k3d-testserver-0 $K3S_URL_LB
+run "$BIN node delete k3d-testserver-0"
+
+clean_up
+
+info "Adding a cluster with no lb to check K3S_URL"
+run "$BIN cluster create $CLUSTER_NAME -s 3 --no-lb"
+
+run "$BIN node create -c $CLUSTER_NAME testagent1"
+check_k3s_url k3d-testagent1-0 $K3S_URL_DEFAULT
+run "$BIN node delete k3d-testagent1-0"
+
+clean_up

--- a/tests/local_test_registration_using_server_lb.sh
+++ b/tests/local_test_registration_using_server_lb.sh
@@ -16,7 +16,7 @@ clean_up() {
 check_k3s_url() {
   local node=$1
   local expected_url=$2
-  local curr_url=$(docker inspect $node | grep K3S_URL | awk -F"=" '{print $2}' | sed 's/",//')
+  local curr_url=$(docker inspect "$node" | grep K3S_URL | awk -F"=" '{print $2}' | sed 's/",//')
 
   if [ "$curr_url" != "$expected_url" ]; then
     failed "Default K3S URL mismatch expected: '${expected_url}' got: ${curr_url}"
@@ -45,6 +45,7 @@ run_with_timeout() {
 
 # Constants for tests
 BIN=k3d
+export EXE=$BIN
 CLUSTER_NAME=test-lb-registration
 K3S_URL_DEFAULT="https://k3d-${CLUSTER_NAME}-server-0:6443"
 K3S_URL_LB="https://k3d-${CLUSTER_NAME}-serverlb:6443"
@@ -53,23 +54,34 @@ clean_up
 info "Starting a multi server cluster"
 run "$BIN cluster create $CLUSTER_NAME -s 3"
 
+check_multi_node $CLUSTER_NAME 3
+
 info "Adding an agent and checking its K3S_URL"
 run_with_timeout "$BIN node create -c $CLUSTER_NAME testagent"
 check_k3s_url k3d-testagent-0 $K3S_URL_DEFAULT
 
+check_multi_node $CLUSTER_NAME 4
+
 info "Deleting server-0"
 run_with_timeout "$BIN node delete k3d-${CLUSTER_NAME}-server-0"
 run "kubectl delete node k3d-${CLUSTER_NAME}-server-0"
+
+check_multi_node $CLUSTER_NAME 3
 
 info "Adding a new agent to check the new K3S_URL"
 run_with_timeout "$BIN node create -c $CLUSTER_NAME testagent1"
 check_k3s_url k3d-testagent1-0 $K3S_URL_LB
 run_with_timeout "$BIN node delete k3d-testagent1-0"
 
+check_multi_node $CLUSTER_NAME 4
+
 info "Adding a new server to check K3S_URL"
 run_with_timeout "$BIN node create -c $CLUSTER_NAME testserver --role server"
 check_k3s_url k3d-testserver-0 $K3S_URL_LB
 run_with_timeout "$BIN node delete k3d-testserver-0"
+
+check_multi_node $CLUSTER_NAME 5
+
 
 clean_up
 


### PR DESCRIPTION
<!-- 
Hi there, have an early THANK YOU for your contribution!
k3d is a community-driven project, so we really highly appreciate any support.
Please make sure, you've read our Code of Conduct and the Contributing Guidelines :)
- Code of Conduct: https://github.com/k3d-io/k3d/blob/main/CODE_OF_CONDUCT.md
- Contributing Guidelines: https://github.com/k3d-io/k3d/blob/main/CONTRIBUTING.md
-->

# What

This PR changes the K3S_URL env value which defaults to server-0 to whichever server is available instead.

# Why

See #1189 

# Implications
It changes the way node create command sets the `K3S_URL` value.
