### PR TITLE
docs: Add missing backtick to k3s-arg example command

### DIFF
--- a/cmd/cluster/clusterCreate.go
+++ b/cmd/cluster/clusterCreate.go
@@ -258,7 +258,7 @@ func NewCmdClusterCreate() *cobra.Command {
 	_ = ppViper.BindPFlag("hostaliases", cmd.Flags().Lookup("host-alias"))
 
 	/* k3s */
-	cmd.Flags().StringArray("k3s-arg", nil, "Additional args passed to k3s command (Format: `ARG@NODEFILTER[;@NODEFILTER]`)\n - Example: `k3d cluster create --k3s-arg \"--disable=traefik@server:0\"")
+	cmd.Flags().StringArray("k3s-arg", nil, "Additional args passed to k3s command (Format: `ARG@NODEFILTER[;@NODEFILTER]`)\n - Example: `k3d cluster create --k3s-arg \"--disable=traefik@server:0\"`")
 	_ = ppViper.BindPFlag("cli.k3sargs", cmd.Flags().Lookup("k3s-arg"))
 
 	/******************


### PR DESCRIPTION
<!-- 
Hi there, have an early THANK YOU for your contribution!
k3d is a community-driven project, so we really highly appreciate any support.
Please make sure, you've read our Code of Conduct and the Contributing Guidelines :)
- Code of Conduct: https://github.com/k3d-io/k3d/blob/main/CODE_OF_CONDUCT.md
- Contributing Guidelines: https://github.com/k3d-io/k3d/blob/main/CONTRIBUTING.md
-->

# What

<!-- What does this PR do or change? -->
Add closing backtick to example command for k3s-arg flag

# Why

<!-- Link issues, discussions, etc. or just explain why you're creating this PR -->
This makes the documentation consistent

# Implications

No changes to existing behavior

<!--
Does this change existing behavior? If so, does it affect the CLI (cmd/) only or does it also/only change some internals of the Go module (pkg/)?
Especially mention breaking changes here!
-->

<!-- Get recognized using our all-contributors bot: https://github.com/k3d-io/k3d/blob/main/CONTRIBUTING.md#get-recognized -->
