### PR TITLE
fix: generate checksum for k3d binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,6 +126,9 @@ build:
 build-cross: LDFLAGS += -extldflags "-static"
 build-cross:
 	CGO_ENABLED=0 gox -parallel=3 -output="_dist/$(BINARIES)-{{.OS}}-{{.Arch}}" -osarch='$(TARGETS)' $(GOFLAGS) $(if $(TAGS),-tags '$(TAGS)',) -ldflags '$(LDFLAGS)'
+gen-checksum:	build-cross
+	$(eval ARTIFACTS_TO_PUBLISH := $(shell ls _dist/*))
+	$$(sha256sum $(ARTIFACTS_TO_PUBLISH) > _dist/checksums.txt)
 
 # build a specific docker target ( '%' matches the target as specified in the Dockerfile)
 build-docker-%:


### PR DESCRIPTION
# What

Generate the release  sha256 checksum file for k3d binaries 

# Why

#1208 , helping to verify the binaries

@all-contributors please add @kameshsampath  for code
