### PR TITLE
changed: update podman service documentation around network dns

### DIFF
--- a/docs/usage/advanced/podman.md
+++ b/docs/usage/advanced/podman.md
@@ -5,13 +5,28 @@ Podman has an [Docker API compatibility layer](https://podman.io/blogs/2020/06/2
 !!! important "Podman support is experimental"
     k3d is not guaranteed to work with Podman. If you find a bug, do help by [filing an issue](https://github.com/k3d-io/k3d/issues/new?labels=bug&template=bug_report.md&title=%5BBUG%5D+Podman)
 
+Tested with podman version:
+```bash
+Client:       Podman Engine
+Version:      4.3.1
+API Version:  4.3.1
+```
+
 ## Using Podman
 
 Ensure the Podman system socket is available:
 
 ```bash
 sudo systemctl enable --now podman.socket
-# or sudo podman system service --time=0
+# or to start the socket daemonless
+# sudo podman system service --time=0 &
+```
+
+Disable timeout for podman service:<br>
+See the [podman-system-service (1)](https://docs.podman.io/en/latest/markdown/podman-system-service.1.html) man page for more information.
+```bash
+mkdir -p /etc/containers/containers.conf.d
+echo 'service_timeout=0' > /etc/containers/containers.conf.d/timeout.conf
 ```
 
 To point k3d at the right Docker socket, create a symbolic link:
@@ -36,7 +51,7 @@ Ensure the Podman user socket is available:
 
 ```bash
 systemctl --user enable --now podman.socket
-# or podman system service --time=0
+# or podman system service --time=0 &
 ```
 
 Set `DOCKER_HOST` when running k3d:
@@ -76,6 +91,15 @@ Reference: [https://rootlesscontaine.rs/getting-started/common/cgroup2/#enabling
 export DOCKER_HOST=ssh://username@hostname
 export DOCKER_SOCK=/run/user/1000/podman/podman.sock
 k3d cluster create
+```
+
+### Podman network
+
+The default `podman` network has dns disabled. To allow k3d cluster nodes to communicate with dns a new network must be created.
+```bash
+podman network create k3d
+podman network inspect k3d -f '{{ .DNSEnabled }}'
+true
 ```
 
 ## Creating local registries


### PR DESCRIPTION


<!-- 
Hi there, have an early THANK YOU for your contribution!
k3d is a community-driven project, so we really highly appreciate any support.
Please make sure, you've read our Code of Conduct and the Contributing Guidelines :)
- Code of Conduct: https://github.com/k3d-io/k3d/blob/main/CODE_OF_CONDUCT.md
- Contributing Guidelines: https://github.com/k3d-io/k3d/blob/main/CONTRIBUTING.md
-->

# What
Update [podman documentation](https://k3d.io/v5.4.1/usage/advanced/podman/)
Add network creation.
Update examples of manaully starting podman socket to start as a background job.

Tested with podman version
```bash
podman version
Client:       Podman Engine
Version:      4.3.1
API Version:  4.3.1
Go Version:   go1.19.2
Built:        Fri Nov 11 15:01:27 2022
OS/Arch:      linux/amd64
```

<!-- What does this PR do or change? -->

# Why
The current documentation doesn't work due to podman's default `podman` network lacking dns. Node's fail to resolve other node names during installation/initialization.

```bash
podman network inspect podman -f '{{ .DNSEnabled }}'
false
```

The examples using `podman system service --time=0` starts a podman socket initiated from that command. I think it's more useful to launch in the background rather than assuming user's will launch another shell.

<!-- Link issues, discussions, etc. or just explain why you're creating this PR -->

# Implications
None that I'm aware of, documentation only.

<!--
Does this change existing behavior? If so, does it affect the CLI (cmd/) only or does it also/only change some internals of the Go module (pkg/)?
Especially mention breaking changes here!
-->

<!-- Get recognized using our all-contributors bot: https://github.com/k3d-io/k3d/blob/main/CONTRIBUTING.md#get-recognized -->
