### PR TITLE
fix: fix for link in doc

### DIFF
--- a/docs/usage/k3s.md
+++ b/docs/usage/k3s.md
@@ -52,7 +52,7 @@ You'd need to map some local directory to that path to easily use the files insi
 
 ### Traefik in k3d
 
-k3d runs K3s in containers, so you'll need to expose the http/https ports on your host to easily access Ingress resources in your cluster. We have a guide over here explaining how to do this: <https://k3d.io/usage/guides/exposing_services/#1-via-ingress-recommended>
+k3d runs K3s in containers, so you'll need to expose the http/https ports on your host to easily access Ingress resources in your cluster. We have a guide over here explaining how to do this, [see](exposing_services.md)
 
 ## servicelb (klipper-lb)
 


### PR DESCRIPTION
<!-- 
Hi there, have an early THANK YOU for your contribution!
k3d is a community-driven project, so we really highly appreciate any support.
Please make sure, you've read our Code of Conduct and the Contributing Guidelines :)
- Code of Conduct: https://github.com/k3d-io/k3d/blob/main/CODE_OF_CONDUCT.md
- Contributing Guidelines: https://github.com/k3d-io/k3d/blob/main/CONTRIBUTING.md
-->

# What

I found a broken link in the 'K3s Features in k3d' section

# Why

The link points to the (I guess) deprecated /guides/ section. I changed the syntax and made it reference the exposing_services.md for a permanent link

# Implications

No implications
<!--
Does this change existing behavior? If so, does it affect the CLI (cmd/) only or does it also/only change some internals of the Go module (pkg/)?
Especially mention breaking changes here!
-->

<!-- Get recognized using our all-contributors bot: https://github.com/k3d-io/k3d/blob/main/CONTRIBUTING.md#get-recognized -->
