### PR TITLE
change: replace deprecated set-output command with environment file in Github Actions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -38,7 +38,7 @@ jobs:
         run: |
           git config --global user.name ghaction-k3d.io
           git config --global user.email ghaction@k3d.io
-          echo ::set-output name=tag::${GITHUB_REF#refs/tags/}
+          echo tag=${GITHUB_REF#refs/tags/} >> $GITHUB_OUTPUT
       - name: Build & Deploy with Mike (versioned)
         if: startsWith(github.ref, 'refs/tags/')
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -214,7 +214,7 @@ jobs:
       - name: Extract Tag from Ref
         if: startsWith(github.ref, 'refs/tags/')
         id: tag
-        run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+        run: echo VERSION=${GITHUB_REF/refs\/tags\//} >> $GITHUB_OUTPUT
         shell: bash
       - uses: apexskier/github-semver-parse@v1
         if: startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
<!-- 
Hi there, have an early THANK YOU for your contribution!
k3d is a community-driven project, so we really highly appreciate any support.
Please make sure, you've read our Code of Conduct and the Contributing Guidelines :)
- Code of Conduct: https://github.com/k3d-io/k3d/blob/main/CODE_OF_CONDUCT.md
- Contributing Guidelines: https://github.com/k3d-io/k3d/blob/main/CONTRIBUTING.md
-->

# What

Update workflows to use environment file instead of deprecated `set-output` command. 
For more information, see: [https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

I found the workflow files that use `set-output` command through the following command:

```bash
$ find . -name '*.yml' -o -name '*.yaml' | xargs egrep '\bset-output\b'
```

# Why

Resolve #1225 