### PR TITLE
fix: handle colima host

### DIFF
--- a/pkg/client/host.go
+++ b/pkg/client/host.go
@@ -91,6 +91,21 @@ func GetHostIP(ctx context.Context, runtime runtimes.Runtime, cluster *k3d.Clust
 
 		}
 
+		// Colima
+		if rtimeInfo.InfoName == "colima" {
+			toolsNode, err := EnsureToolsNode(ctx, runtime, cluster)
+			if err != nil {
+				return nil, fmt.Errorf("failed to ensure that k3d-tools node is running to get host IP :%w", err)
+			}
+
+			limaIP, err := resolveHostnameFromInside(ctx, runtime, toolsNode, "host.lima.internal", ResolveHostCmdGetEnt)
+			if err == nil {
+				return limaIP, nil
+			}
+
+			l.Log().Debugf("[GetHostIP on colima] failed to resolve 'host.lima.internal' from inside the k3d-tools node: %v", err)
+		}
+
 		ip, err := runtime.GetHostIP(ctx, cluster.Network.Name)
 		if err != nil {
 			return nil, fmt.Errorf("runtime failed to get host IP: %w", err)

--- a/pkg/runtimes/docker/info.go
+++ b/pkg/runtimes/docker/info.go
@@ -53,6 +53,7 @@ func (d Docker) Info() (*runtimeTypes.RuntimeInfo, error) {
 		CgroupVersion: info.CgroupVersion,
 		CgroupDriver:  info.CgroupDriver,
 		Filesystem:    "UNKNOWN",
+		InfoName:      info.Name,
 	}
 
 	// Get the backing filesystem for the storage driver

--- a/pkg/runtimes/types/types.go
+++ b/pkg/runtimes/types/types.go
@@ -31,6 +31,7 @@ type RuntimeInfo struct {
 	CgroupVersion string `json:"cgroupversion,omitempty"`
 	CgroupDriver  string `json:"cgroupdriver,omitempty"`
 	Filesystem    string `json:"filesystem,omitempty"`
+	InfoName      string `json:"infoname,omitempty"`
 }
 
 type NodeLogsOpts struct {


### PR DESCRIPTION
k3d mostly works flawlessly on github.com/abiosoft/colima, but host.k3d.interal points to nowhere useful. We detect colima runtime by the name in docker info output, then resolve the host IP by querying host.lima.internal.

How to test:

$ colima start
$ k3d cluster create
$ nc -l 0.0.0.0 1234

In another terminal

$ kubectl run -it --rm --image alpine:latest test --  /bin/sh -c 'echo "hello there" | nc host.k3d.internal 1234'

<!-- 
Hi there, have an early THANK YOU for your contribution!
k3d is a community-driven project, so we really highly appreciate any support.
Please make sure, you've read our Code of Conduct and the Contributing Guidelines :)
- Code of Conduct: https://github.com/k3d-io/k3d/blob/main/CODE_OF_CONDUCT.md
- Contributing Guidelines: https://github.com/k3d-io/k3d/blob/main/CONTRIBUTING.md
-->

# What
Fixes HostIP detection when running on Colima.

# Why
To fix host.k3d.internal

# Implications
Unsure. Works on my machine with the patch...
<!--
Does this change existing behavior? If so, does it affect the CLI (cmd/) only or does it also/only change some internals of the Go module (pkg/)?
Especially mention breaking changes here!
-->

<!-- Get recognized using our all-contributors bot: https://github.com/k3d-io/k3d/blob/main/CONTRIBUTING.md#get-recognized -->
