### PR TITLE
Adds json response of version info

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -223,9 +223,9 @@ func NewCmdVersion() *cobra.Command {
 		Short: "Show k3d and default k3s version",
 		Long:  "Show k3d and default k3s version",
 		Run: func(cmd *cobra.Command, args []string) {
-			format, _ := cmd.Flags().GetString("format")
+			output, _ := cmd.Flags().GetString("output")
 
-			if format == string(VersionOutputFormatJson) {
+			if output == string(VersionOutputFormatJson) {
 				printJsonVersion()
 			} else {
 				printVersion()
@@ -234,7 +234,8 @@ func NewCmdVersion() *cobra.Command {
 		Args: cobra.NoArgs,
 	}
 
-	cmd.Flags().String("format", "raw", "This will return version information as a different format.  Only json is supported")
+	cmd.Flags().StringP("output", "o", "", "This will return version information as a different format.  Only json is supported")
+
 	cmd.AddCommand(NewCmdVersionLs())
 
 	return cmd

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -58,6 +58,11 @@ type RootFlags struct {
 	version            bool
 }
 
+type VersionInfo struct {
+	K3d string `json:"k3d"`
+	K3s string `json:"k3s"`
+}
+
 var flags = RootFlags{}
 
 func NewCmdK3d() *cobra.Command {
@@ -207,20 +212,45 @@ func initRuntime() {
 }
 
 func NewCmdVersion() *cobra.Command {
+	type VersionOutputFormat string
+
+	const (
+		VersionOutputFormatJson VersionOutputFormat = "json"
+	)
+
 	cmd := &cobra.Command{
 		Use:   "version",
 		Short: "Show k3d and default k3s version",
 		Long:  "Show k3d and default k3s version",
 		Run: func(cmd *cobra.Command, args []string) {
-			printVersion()
+			format, _ := cmd.Flags().GetString("format")
+
+			if format == string(VersionOutputFormatJson) {
+				printJsonVersion()
+			} else {
+				printVersion()
+			}
 		},
 		Args: cobra.NoArgs,
 	}
 
+	cmd.Flags().String("format", "raw", "This will return version information as a different format.  Only json is supported")
 	cmd.AddCommand(NewCmdVersionLs())
 
 	return cmd
+}
 
+func printJsonVersion() {
+	versionInfo := VersionInfo{
+		K3d: version.GetVersion(),
+		K3s: version.K3sVersion,
+	}
+	versionJson, err := json.Marshal(versionInfo)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	fmt.Println(string(versionJson))
 }
 
 func printVersion() {


### PR DESCRIPTION
<!-- 
Hi there, have an early THANK YOU for your contribution!
k3d is a community-driven project, so we really highly appreciate any support.
Please make sure, you've read our Code of Conduct and the Contributing Guidelines :)
- Code of Conduct: https://github.com/k3d-io/k3d/blob/main/CODE_OF_CONDUCT.md
- Contributing Guidelines: https://github.com/k3d-io/k3d/blob/main/CONTRIBUTING.md
-->

# What

This adds a flag to be able to return the response of the `version` command and return it as JSON.  

# Why

I couldn't find an easier way to parse out what the latest version of K3S that K3D is using easily.

# Implications

<!--
Does this change existing behavior? If so, does it affect the CLI (cmd/) only or does it also/only change some internals of the Go module (pkg/)?
Especially mention breaking changes here!
-->

This adds new behavior and should likely not impact any existing other CLI commands.  It does not modify any `pkg` internals.  No breaking changes.

<!-- Get recognized using our all-contributors bot: https://github.com/k3d-io/k3d/blob/main/CONTRIBUTING.md#get-recognized -->

@all-contributors please add @dgershman for code