### PR TITLE
add: K3D_FIX_MOUNTS fix to make / rshared (e.g. to make Cilium work)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -200,7 +200,7 @@ jobs:
         run: make ci-setup
       # Go Build
       - name: Build k3d Binary
-        run: make build-cross
+        run: make gen-checksum build-cross
       # Wait for tests to pass and create release (ONLY ON TAG)
       - name: Wait for tests to succeed
         if: startsWith(github.ref, 'refs/tags/')

--- a/pkg/client/node.go
+++ b/pkg/client/node.go
@@ -566,6 +566,25 @@ func enableFixes(ctx context.Context, runtime runtimes.Runtime, node *k3d.Node, 
 				},
 			})
 		}
+
+		if fixes.FixEnabled(fixes.EnvFixMounts) {
+			l.Log().Debugf(">>> enabling mounts magic")
+
+			if nodeStartOpts.NodeHooks == nil {
+				nodeStartOpts.NodeHooks = []k3d.NodeHook{}
+			}
+
+			nodeStartOpts.NodeHooks = append(nodeStartOpts.NodeHooks, k3d.NodeHook{
+				Stage: k3d.LifecycleStagePreStart,
+				Action: actions.WriteFileAction{
+					Runtime:     runtime,
+					Content:     fixes.MountsEntrypoint,
+					Dest:        "/bin/k3d-entrypoint-mounts.sh",
+					Mode:        0744,
+					Description: "Write entrypoint script for mounts fix",
+				},
+			})
+		}
 	}
 	return nil
 }

--- a/pkg/types/env.go
+++ b/pkg/types/env.go
@@ -39,4 +39,5 @@ const (
 	// Fixes
 	K3dEnvFixCgroupV2 = "K3D_FIX_CGROUPV2"
 	K3dEnvFixDNS      = "K3D_FIX_DNS"
+	K3dEnvFixMounts   = "K3D_FIX_MOUNTS"
 )

--- a/pkg/types/fixes/assets/k3d-entrypoint-mounts.sh
+++ b/pkg/types/fixes/assets/k3d-entrypoint-mounts.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+set -o errexit
+set -o nounset
+
+echo "[$(date -Iseconds)] [Mounts] Fixing Mountpoints..."
+
+mount --make-rshared /

--- a/pkg/types/fixes/fixes.go
+++ b/pkg/types/fixes/fixes.go
@@ -43,12 +43,14 @@ type K3DFixEnv string
 
 const (
 	EnvFixCgroupV2 K3DFixEnv = k3d.K3dEnvFixCgroupV2 // EnvFixCgroupV2 is the environment variable that k3d will check for to enable/disable the cgroupv2 workaround
-	EnvFixDNS      K3DFixEnv = k3d.K3dEnvFixDNS      // EnvFixDNS is the environment variable that check for to enable/disable the application of network magic related to DNS
+	EnvFixDNS      K3DFixEnv = k3d.K3dEnvFixDNS      // EnvFixDNS is the environment variable that k3d will check for to enable/disable the application of network magic related to DNS
+	EnvFixMounts   K3DFixEnv = k3d.K3dEnvFixMounts   // EnvFixMounts is the environment variable that k3d will check for to enable/disable the fixing of mountpoints
 )
 
 var FixEnvs []K3DFixEnv = []K3DFixEnv{
 	EnvFixCgroupV2,
 	EnvFixDNS,
+	EnvFixMounts,
 }
 
 //go:embed assets/k3d-entrypoint-cgroupv2.sh
@@ -56,6 +58,9 @@ var CgroupV2Entrypoint []byte
 
 //go:embed assets/k3d-entrypoint-dns.sh
 var DNSMagicEntrypoint []byte
+
+//go:embed assets/k3d-entrypoint-mounts.sh
+var MountsEntrypoint []byte
 
 //go:embed assets/k3d-entrypoint.sh
 var K3DEntrypoint []byte


### PR DESCRIPTION
<!-- 
Hi there, have an early THANK YOU for your contribution!
k3d is a community-driven project, so we really highly appreciate any support.
Please make sure, you've read our Code of Conduct and the Contributing Guidelines :)
- Code of Conduct: https://github.com/k3d-io/k3d/blob/main/CODE_OF_CONDUCT.md
- Contributing Guidelines: https://github.com/k3d-io/k3d/blob/main/CONTRIBUTING.md
-->

# What

New env var `K3D_FIX_MOUNTS`, set it to e.g. `K3D_FIX_MOUNTS=1` to make `/` in the node containers `rshared` mounts.
This fixes e.g. the setup of Cilium.

If there are no bad implications of this and no one raises issues while using it throughout a few versions, we can add it as a default entrypoint.

# Why

#1063 

# Implications

<!--
Does this change existing behavior? If so, does it affect the CLI (cmd/) only or does it also/only change some internals of the Go module (pkg/)?
Especially mention breaking changes here!
-->

<!-- Get recognized using our all-contributors bot: https://github.com/k3d-io/k3d/blob/main/CONTRIBUTING.md#get-recognized -->
