### PR TITLE
docs: update go install command

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -114,7 +114,7 @@ Use the install script to grab a specific release (via `TAG` environment variabl
       *Note*: `asdf plugin-add k3d`, then `asdf install k3d <tag>` with `<tag> = latest` or `5.x.x` for a specific version (maintained by [spencergilbert/asdf-k3d](https://github.com/spencergilbert/asdf-k3d))
 
     - Others
-      - install via go: `#!bash go install github.com/k3d-io/k3d@latest` (**Note**: this will give you unreleased/bleeding-edge changes)
+      - install via go: `#!bash go install github.com/k3d-io/k3d/v5@latest` (**Note**: this will give you unreleased/bleeding-edge changes)
 
 ## Quick Start
 


### PR DESCRIPTION
# What

The PR updates Overview section of documentation to update the ```go install``` command

# Why

As mentioned in https://github.com/k3d-io/k3d/issues/1274

# Implications

The PR does not change any existing behavior of the application. It changes the installation method using ```go``` command
