### PR TITLE
[FEATURE] Allow changing the cluster name using environment variables

### DIFF
--- a/cmd/cluster/clusterCreate.go
+++ b/cmd/cluster/clusterCreate.go
@@ -118,6 +118,8 @@ func NewCmdClusterCreate() *cobra.Command {
 			// Set the name
 			if len(args) != 0 {
 				simpleCfg.Name = args[0]
+			} else if os.Getenv("K3D_CLUSTER_NAME") != "" {
+				simpleCfg.Name = os.Getenv("K3D_CLUSTER_NAME")
 			}
 
 			if err := config.ProcessSimpleConfig(&simpleCfg); err != nil {

--- a/cmd/cluster/clusterCreate.go
+++ b/cmd/cluster/clusterCreate.go
@@ -73,6 +73,9 @@ var (
 func initConfig() error {
 	// Viper for pre-processed config options
 	ppViper.SetEnvPrefix("K3D")
+	if err := ppViper.BindEnv("CLUSTER_NAME"); err != nil {
+		return err
+	}
 
 	if l.Log().GetLevel() >= logrus.DebugLevel {
 		c, _ := yaml.Marshal(ppViper.AllSettings())
@@ -118,8 +121,8 @@ func NewCmdClusterCreate() *cobra.Command {
 			// Set the name
 			if len(args) != 0 {
 				simpleCfg.Name = args[0]
-			} else if os.Getenv("K3D_CLUSTER_NAME") != "" {
-				simpleCfg.Name = os.Getenv("K3D_CLUSTER_NAME")
+			} else if ppViper.GetString("CLUSTER_NAME") != "" {
+				simpleCfg.Name = ppViper.GetString("CLUSTER_NAME")
 			}
 
 			if err := config.ProcessSimpleConfig(&simpleCfg); err != nil {

--- a/cmd/cluster/clusterDelete.go
+++ b/cmd/cluster/clusterDelete.go
@@ -41,6 +41,7 @@ import (
 )
 
 var clusterDeleteConfigFile string
+var clusterDeletePpViper = viper.New()
 var clusterDeleteCfgViper = viper.New()
 
 // NewCmdClusterDelete returns a new cobra command
@@ -54,6 +55,11 @@ func NewCmdClusterDelete() *cobra.Command {
 		Args:              cobra.MinimumNArgs(0), // 0 or n arguments; 0 = default cluster name
 		ValidArgsFunction: util.ValidArgsAvailableClusters,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
+			// Preprocessed config
+			clusterDeletePpViper.SetEnvPrefix("K3D")
+			if err := clusterDeletePpViper.BindEnv("CLUSTER_NAME"); err != nil {
+				return err
+			}
 			return cliconfig.InitViperWithConfigFile(clusterDeleteCfgViper, clusterDeleteConfigFile)
 		},
 		Run: func(cmd *cobra.Command, args []string) {
@@ -158,8 +164,8 @@ func parseDeleteClusterCmd(cmd *cobra.Command, args []string) []*k3d.Cluster {
 	clusternames := []string{k3d.DefaultClusterName}
 	if len(args) != 0 {
 		clusternames = args
-	} else if os.Getenv("K3D_CLUSTER_NAME") != "" {
-		clusternames = []string{os.Getenv("K3D_CLUSTER_NAME")}
+	} else if clusterDeletePpViper.GetString("CLUSTER_NAME") != "" {
+		clusternames = []string{clusterDeletePpViper.GetString("CLUSTER_NAME")}
 	}
 
 	for _, name := range clusternames {

--- a/cmd/cluster/clusterDelete.go
+++ b/cmd/cluster/clusterDelete.go
@@ -158,6 +158,8 @@ func parseDeleteClusterCmd(cmd *cobra.Command, args []string) []*k3d.Cluster {
 	clusternames := []string{k3d.DefaultClusterName}
 	if len(args) != 0 {
 		clusternames = args
+	} else if os.Getenv("K3D_CLUSTER_NAME") != "" {
+		clusternames = []string{os.Getenv("K3D_CLUSTER_NAME")}
 	}
 
 	for _, name := range clusternames {

--- a/cmd/cluster/clusterStart.go
+++ b/cmd/cluster/clusterStart.go
@@ -22,7 +22,6 @@ THE SOFTWARE.
 package cluster
 
 import (
-	"os"
 	"time"
 
 	"github.com/k3d-io/k3d/v5/cmd/util"
@@ -30,10 +29,13 @@ import (
 	"github.com/k3d-io/k3d/v5/pkg/runtimes"
 	"github.com/k3d-io/k3d/v5/pkg/types"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 
 	l "github.com/k3d-io/k3d/v5/pkg/logger"
 	k3d "github.com/k3d-io/k3d/v5/pkg/types"
 )
+
+var clusterStartPpViper = viper.New()
 
 // NewCmdClusterStart returns a new cobra command
 func NewCmdClusterStart() *cobra.Command {
@@ -47,6 +49,11 @@ func NewCmdClusterStart() *cobra.Command {
 		Long:              `Start existing k3d cluster(s)`,
 		Short:             "Start existing k3d cluster(s)",
 		ValidArgsFunction: util.ValidArgsAvailableClusters,
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			clusterStartPpViper.SetEnvPrefix("K3D")
+			err := clusterStartPpViper.BindEnv("CLUSTER_NAME")
+			return err
+		},
 		Run: func(cmd *cobra.Command, args []string) {
 			clusters := parseStartClusterCmd(cmd, args)
 			if len(clusters) == 0 {
@@ -107,8 +114,8 @@ func parseStartClusterCmd(cmd *cobra.Command, args []string) []*k3d.Cluster {
 	clusternames := []string{k3d.DefaultClusterName}
 	if len(args) != 0 {
 		clusternames = args
-	} else if os.Getenv("K3D_CLUSTER_NAME") != "" {
-		clusternames = []string{os.Getenv("K3D_CLUSTER_NAME")}
+	} else if clusterStartPpViper.GetString("CLUSTER_NAME") != "" {
+		clusternames = []string{clusterStartPpViper.GetString("CLUSTER_NAME")}
 	}
 
 	for _, name := range clusternames {

--- a/cmd/cluster/clusterStart.go
+++ b/cmd/cluster/clusterStart.go
@@ -22,6 +22,7 @@ THE SOFTWARE.
 package cluster
 
 import (
+	"os"
 	"time"
 
 	"github.com/k3d-io/k3d/v5/cmd/util"
@@ -106,6 +107,8 @@ func parseStartClusterCmd(cmd *cobra.Command, args []string) []*k3d.Cluster {
 	clusternames := []string{k3d.DefaultClusterName}
 	if len(args) != 0 {
 		clusternames = args
+	} else if os.Getenv("K3D_CLUSTER_NAME") != "" {
+		clusternames = []string{os.Getenv("K3D_CLUSTER_NAME")}
 	}
 
 	for _, name := range clusternames {

--- a/cmd/cluster/clusterStop.go
+++ b/cmd/cluster/clusterStop.go
@@ -22,9 +22,8 @@ THE SOFTWARE.
 package cluster
 
 import (
-	"os"
-
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 
 	"github.com/k3d-io/k3d/v5/cmd/util"
 	"github.com/k3d-io/k3d/v5/pkg/client"
@@ -32,6 +31,8 @@ import (
 	"github.com/k3d-io/k3d/v5/pkg/runtimes"
 	k3d "github.com/k3d-io/k3d/v5/pkg/types"
 )
+
+var clusterStopPpViper = viper.New()
 
 // NewCmdClusterStop returns a new cobra command
 func NewCmdClusterStop() *cobra.Command {
@@ -41,6 +42,11 @@ func NewCmdClusterStop() *cobra.Command {
 		Short:             "Stop existing k3d cluster(s)",
 		Long:              `Stop existing k3d cluster(s).`,
 		ValidArgsFunction: util.ValidArgsAvailableClusters,
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			clusterStopPpViper.SetEnvPrefix("K3D")
+			err := clusterStopPpViper.BindEnv("CLUSTER_NAME")
+			return err
+		},
 		Run: func(cmd *cobra.Command, args []string) {
 			clusters := parseStopClusterCmd(cmd, args)
 			if len(clusters) == 0 {
@@ -82,8 +88,8 @@ func parseStopClusterCmd(cmd *cobra.Command, args []string) []*k3d.Cluster {
 	clusternames := []string{k3d.DefaultClusterName}
 	if len(args) != 0 {
 		clusternames = args
-	} else if os.Getenv("K3D_CLUSTER_NAME") != "" {
-		clusternames = []string{os.Getenv("K3D_CLUSTER_NAME")}
+	} else if clusterStopPpViper.GetString("CLUSTER_NAME") != "" {
+		clusternames = []string{clusterStopPpViper.GetString("CLUSTER_NAME")}
 	}
 
 	for _, name := range clusternames {

--- a/cmd/cluster/clusterStop.go
+++ b/cmd/cluster/clusterStop.go
@@ -22,6 +22,8 @@ THE SOFTWARE.
 package cluster
 
 import (
+	"os"
+
 	"github.com/spf13/cobra"
 
 	"github.com/k3d-io/k3d/v5/cmd/util"
@@ -80,6 +82,8 @@ func parseStopClusterCmd(cmd *cobra.Command, args []string) []*k3d.Cluster {
 	clusternames := []string{k3d.DefaultClusterName}
 	if len(args) != 0 {
 		clusternames = args
+	} else if os.Getenv("K3D_CLUSTER_NAME") != "" {
+		clusternames = []string{os.Getenv("K3D_CLUSTER_NAME")}
 	}
 
 	for _, name := range clusternames {


### PR DESCRIPTION
# What

Adds new functionality to check for env variable for cluster name. The variable is named K3D_CLUSTER_NAME

# Why

Closes https://github.com/k3d-io/k3d/issues/1281

# Implications

<!--
Does this change existing behavior? If so, does it affect the CLI (cmd/) only or does it also/only change some internals of the Go module (pkg/)?
Especially mention breaking changes here!
-->

The PR changes the default behavior of cluster commands including create, delete, start, stop. After this change, k3d will first look for env variable named K3D_CLUSTER_NAME and create cluster with the value provided by the variable. It should be noted that env variable has less preference than config file, so it only acts when neither of the config file or the command line provides cluster name 

<!-- Get recognized using our all-contributors bot: https://github.com/k3d-io/k3d/blob/main/CONTRIBUTING.md#get-recognized -->
