### PR TITLE
[BUG] fix to make / rshared for windows and ubuntu

### DIFF
--- a/pkg/client/node.go
+++ b/pkg/client/node.go
@@ -580,6 +580,14 @@ func enableFixes(ctx context.Context, runtime runtimes.Runtime, node *k3d.Node, 
 					Mode:        0744,
 					Description: "Write entrypoint script for mounts fix",
 				},
+			}, k3d.NodeHook{
+				Stage: k3d.LifecycleStagePostStart,
+				Action: actions.ExecAction{
+					Runtime:     runtimes.SelectedRuntime,
+					Command:     []string{"sh", "-c", " /bin/k3d-entrypoint-mounts.sh"},
+					Description: "Execute entrypoint script for mount shared fix",
+					Retries:     5,
+				},
 			})
 		}
 	}


### PR DESCRIPTION
<!-- 
Hi there, have an early THANK YOU for your contribution!
k3d is a community-driven project, so we really highly appreciate any support.
Please make sure, you've read our Code of Conduct and the Contributing Guidelines :)
- Code of Conduct: https://github.com/k3d-io/k3d/blob/main/CODE_OF_CONDUCT.md
- Contributing Guidelines: https://github.com/k3d-io/k3d/blob/main/CONTRIBUTING.md
-->

# What
Add an `ExecAction` for the k3d-entrypoint-mounts.sh.

# Why

- fix : #1301 

# Implications