### PR TITLE
fix(go.mod): go mod list dependency incorrect

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -39,6 +39,8 @@ require (
 
 replace github.com/rancher/wharfie => github.com/iwilltry42/wharfie v0.6.2-iwilltry42.0
 
+replace k8s.io/kubelet => k8s.io/kubelet v0.27.2
+
 require (
 	github.com/goodhosts/hostsfile v0.1.1
 	github.com/google/go-containerregistry v0.12.2-0.20230106184643-b063f6aeac72


### PR DESCRIPTION
<!-- 
Hi there, have an early THANK YOU for your contribution!
k3d is a community-driven project, so we really highly appreciate any support.
Please make sure, you've read our Code of Conduct and the Contributing Guidelines :)
- Code of Conduct: https://github.com/k3d-io/k3d/blob/main/CODE_OF_CONDUCT.md
- Contributing Guidelines: https://github.com/k3d-io/k3d/blob/main/CONTRIBUTING.md
-->

# What
It makes the indexing fail in goland idea
<!-- What does this PR do or change? -->
```
go list -m -json -mod=readonly all
go: k8s.io/kubelet@v0.0.0: reading https://goproxy.cn/k8s.io/kubelet/@v/v0.0.0.info: 404 Not Found
	server response: not found: k8s.io/kubelet@v0.0.0: invalid version: unknown revision v0.0.0
```
# Why
Include useless reference
https://github.com/iwilltry42/wharfie/blob/main/go.mod#LL87C2-L87C35
<!-- Link issues, discussions, etc. or just explain why you're creating this PR -->

# Implications
Only using goland idea.
<!--
Does this change existing behavior? If so, does it affect the CLI (cmd/) only or does it also/only change some internals of the Go module (pkg/)?
Especially mention breaking changes here!
-->

<!-- Get recognized using our all-contributors bot: https://github.com/k3d-io/k3d/blob/main/CONTRIBUTING.md#get-recognized -->
