### PR TITLE
Adhere to XDG's configuration specification

### DIFF
--- a/pkg/types/defaults.go
+++ b/pkg/types/defaults.go
@@ -74,7 +74,7 @@ const DefaultK3dInternalHostRecord = "host.k3d.internal"
 const DefaultImageVolumeMountPath = "/k3d/images"
 
 // DefaultConfigDirName defines the name of the config directory (where we'll e.g. put the kubeconfigs)
-const DefaultConfigDirName = ".k3d" // should end up in $HOME/
+const DefaultConfigDirName = ".config/k3d" // should end up in $XDG_CONFIG_HOME
 
 // DefaultKubeconfigPrefix defines the default prefix for kubeconfig files
 const DefaultKubeconfigPrefix = DefaultObjectNamePrefix + "-kubeconfig"

--- a/pkg/util/files.go
+++ b/pkg/util/files.go
@@ -26,19 +26,23 @@ import (
 	"os"
 	"path"
 
-	"github.com/k3d-io/k3d/v5/pkg/types"
 	homedir "github.com/mitchellh/go-homedir"
+
+	"github.com/k3d-io/k3d/v5/pkg/types"
 )
 
 // GetConfigDirOrCreate will return the base path of the k3d config directory or create it if it doesn't exist yet
-// k3d's config directory will be $HOME/.k3d (Unix)
+// k3d's config directory will be $XDG_CONFIG_HOME (Unix)
 func GetConfigDirOrCreate() (string, error) {
-	// build the path
-	homeDir, err := homedir.Dir()
-	if err != nil {
-		return "", fmt.Errorf("failed to get user's home directory: %w", err)
+	configDir := os.Getenv("XDG_CONFIG_HOME")
+	if len(configDir) == 0 {
+		// build the path
+		homeDir, err := homedir.Dir()
+		if err != nil {
+			return "", fmt.Errorf("failed to get user's home directory: %w", err)
+		}
+		configDir = path.Join(homeDir, types.DefaultConfigDirName)
 	}
-	configDir := path.Join(homeDir, types.DefaultConfigDirName)
 
 	// create directories if necessary
 	if err := createDirIfNotExists(configDir); err != nil {

--- a/pkg/util/files.go
+++ b/pkg/util/files.go
@@ -26,6 +26,7 @@ import (
 	"os"
 	"path"
 
+	"github.com/k3d-io/k3d/v5/pkg/types"
 	homedir "github.com/mitchellh/go-homedir"
 )
 
@@ -37,7 +38,7 @@ func GetConfigDirOrCreate() (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("failed to get user's home directory: %w", err)
 	}
-	configDir := path.Join(homeDir, ".k3d")
+	configDir := path.Join(homeDir, types.DefaultConfigDirName)
 
 	// create directories if necessary
 	if err := createDirIfNotExists(configDir); err != nil {


### PR DESCRIPTION
# What
This patch set makes 3 changes:

- Ensure the `DefaultConfigDirName` constant is used when creating the config directory;
- Set the `DefaultConfigDirName` constant to the XDG default path for configuration;
- Make the function `GetConfigDirOrCreate` check the environment variable `XDG_CONFIG_HOME` before using the default value;


# Why
Standardization, organization and customization.

# Implications
This change makes the program more predictable, as most Unix tooling already uses the paths from the specification. Furthermore, it makes it more customizable, since the configuration path can be changed through a mere env var.
