### PR TITLE
Not using stdout directly for logging

### DIFF
--- a/pkg/runtimes/docker/container.go
+++ b/pkg/runtimes/docker/container.go
@@ -26,7 +26,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"os"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
@@ -117,7 +116,7 @@ func pullImage(ctx context.Context, docker client.APIClient, image string) error
 	// in debug mode (--verbose flag set), output pull progress
 	var writer io.Writer = io.Discard
 	if l.Log().GetLevel() == logrus.DebugLevel {
-		writer = os.Stdout
+		writer = l.Log().Out
 	}
 	_, err = io.Copy(writer, resp)
 	if err != nil {


### PR DESCRIPTION
<!-- 
Hi there, have an early THANK YOU for your contribution!
k3d is a community-driven project, so we really highly appreciate any support.
Please make sure, you've read our Code of Conduct and the Contributing Guidelines :)
- Code of Conduct: https://github.com/k3d-io/k3d/blob/main/CODE_OF_CONDUCT.md
- Contributing Guidelines: https://github.com/k3d-io/k3d/blob/main/CONTRIBUTING.md
-->

# What
Not using `io.stdout` directly, instead using the `logger.Out`
<!-- What does this PR do or change? -->

# Why
It allows control logger output destination - (e.g printing logs to a file)
<!-- Link issues, discussions, etc. or just explain why you're creating this PR -->

# Implications
No known implications
<!--
Does this change existing behavior? If so, does it affect the CLI (cmd/) only or does it also/only change some internals of the Go module (pkg/)?
Especially mention breaking changes here!
-->

<!-- Get recognized using our all-contributors bot: https://github.com/k3d-io/k3d/blob/main/CONTRIBUTING.md#get-recognized -->
