### PR TITLE
Consistent logging during cluster creation flow

### DIFF
--- a/pkg/runtimes/docker/node.go
+++ b/pkg/runtimes/docker/node.go
@@ -118,7 +118,7 @@ func (d Docker) StartNode(ctx context.Context, node *k3d.Node) error {
 	}
 
 	// actually start the container
-	l.Log().Infof("Starting Node '%s'", node.Name)
+	l.Log().Infof("Starting node '%s'", node.Name)
 	if err := docker.ContainerStart(ctx, nodeContainer.ID, types.ContainerStartOptions{}); err != nil {
 		return fmt.Errorf("docker failed to start container for node '%s': %w", node.Name, err)
 	}


### PR DESCRIPTION
<!-- 
Hi there, have an early THANK YOU for your contribution!
k3d is a community-driven project, so we really highly appreciate any support.
Please make sure, you've read our Code of Conduct and the Contributing Guidelines :)
- Code of Conduct: https://github.com/k3d-io/k3d/blob/main/CODE_OF_CONDUCT.md
- Contributing Guidelines: https://github.com/k3d-io/k3d/blob/main/CONTRIBUTING.md
-->
Haha, you might either laugh or get annoyed at this PR, but...

# What

I've changed the initial Info log regarding node start-up because it seems inconsistent with the other logs.

``` text
...
INFO[0000] Starting Node 'k3d-cluster-tools'
INFO[0001] Creating node 'k3d-cluster-server-0'
...
```

The `Starting Node` log is the only one that's using a starting upper case convention for its object so I thought I'd make it consistent.

What makes this particularly more annoying than just having this inconsistency elsewhere is that this is part of the first command that a newcomer trying out the tool will run, i.e. `k3d cluster create ...`.

<img width="982" alt="image" src="https://github.com/k3d-io/k3d/assets/9533366/0377c30c-c2ec-42ea-920f-712683089ee2">

