### PR TITLE
feat: support config embedded and external files

### DIFF
--- a/cmd/cluster/clusterCreate.go
+++ b/cmd/cluster/clusterCreate.go
@@ -123,7 +123,7 @@ func NewCmdClusterCreate() *cobra.Command {
 				l.Log().Fatalf("error processing/sanitizing simple config: %v", err)
 			}
 
-			clusterConfig, err := config.TransformSimpleToClusterConfig(cmd.Context(), runtimes.SelectedRuntime, simpleCfg)
+			clusterConfig, err := config.TransformSimpleToClusterConfig(cmd.Context(), runtimes.SelectedRuntime, simpleCfg, configFile)
 			if err != nil {
 				l.Log().Fatalln(err)
 			}

--- a/pkg/client/cluster.go
+++ b/pkg/client/cluster.go
@@ -247,6 +247,25 @@ func ClusterPrep(ctx context.Context, runtime k3drt.Runtime, clusterConfig *conf
 		})
 	}
 
+	/*
+	 * Step 4: Files
+	 */
+
+	for id, node := range clusterConfig.Nodes {
+		for _, nodefile := range node.Files {
+			clusterConfig.Nodes[id].HookActions = append(clusterConfig.Nodes[id].HookActions, k3d.NodeHook{
+				Stage: k3d.LifecycleStagePreStart,
+				Action: actions.WriteFileAction{
+					Runtime:     runtime,
+					Content:     nodefile.Content,
+					Dest:        nodefile.Destination,
+					Mode:        0644,
+					Description: nodefile.Description,
+				},
+			})
+		}
+	}
+
 	return nil
 }
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -71,6 +71,34 @@ func TestReadSimpleConfig(t *testing.T) {
 				NodeFilters: []string{"all"},
 			},
 		},
+		Files: []conf.FileWithNodeFilters{
+			{
+				Source: "apiVersion: v1\n" +
+					"kind: Namespace\n" +
+					"metadata:\n" +
+					"  name: foo\n",
+				Destination: "/var/lib/rancher/k3s/server/manifests/foo.yaml",
+			},
+			{
+				Source: "apiVersion: v1\n" +
+					"kind: Namespace\n" +
+					"metadata:\n" +
+					"  name: bar\n",
+				Destination: "k3s-manifests/bar.yaml",
+				Description: "Source: Embedded content in k3d config file, Destination: Magic shortcut path, Description: Defined",
+			},
+			{
+				Source:      "baz-ns.yaml",
+				Destination: "k3s-manifests-custom/baz.yaml",
+				Description: "Source: Relative path to k3d config file, Destination: Magic shortcut path, Description: Defined",
+			},
+			{
+				Source:      "baz-ns.yaml",
+				Destination: "k3s-manifests-custom/baz-server.yaml",
+				NodeFilters: []string{"server:*"},
+				Description: "Source: Relative path to k3d config file, Destination: Magic shortcut path, Node: Defined, Description: Defined",
+			},
+		},
 		Options: conf.SimpleConfigOptions{
 			K3dOptions: conf.SimpleConfigOptionsK3d{
 				Wait:                true,

--- a/pkg/config/process_test.go
+++ b/pkg/config/process_test.go
@@ -48,7 +48,7 @@ func TestProcessClusterConfig(t *testing.T) {
 
 	t.Logf("\n========== Read Config and transform to cluster ==========\n%+v\n=================================\n", cfg)
 
-	clusterCfg, err := TransformSimpleToClusterConfig(context.Background(), runtimes.Docker, cfg.(conf.SimpleConfig))
+	clusterCfg, err := TransformSimpleToClusterConfig(context.Background(), runtimes.Docker, cfg.(conf.SimpleConfig), cfgFile)
 	if err != nil {
 		t.Error(err)
 	}

--- a/pkg/config/test_assets/baz-ns.yaml
+++ b/pkg/config/test_assets/baz-ns.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: baz

--- a/pkg/config/test_assets/config_test_simple.yaml
+++ b/pkg/config/test_assets/config_test_simple.yaml
@@ -23,6 +23,29 @@ env:
   - envVar: bar=baz
     nodeFilters:
       - all
+files:
+ - source: |
+    apiVersion: v1
+    kind: Namespace
+    metadata:
+      name: foo
+   destination: /var/lib/rancher/k3s/server/manifests/foo.yaml
+   # destination: "Source: Embedded content in k3d config file, Destination: Absolute path, Description: Not defined"
+ - source: |
+    apiVersion: v1
+    kind: Namespace
+    metadata:
+      name: bar
+   destination: k3s-manifests/bar.yaml # Resolved to /var/lib/rancher/k3s/server/manifests/bar.yaml
+   description: 'Source: Embedded content in k3d config file, Destination: Magic shortcut path, Description: Defined'
+ - source: baz-ns.yaml
+   destination: k3s-manifests-custom/baz.yaml # Resolved to /var/lib/rancher/k3s/server/manifests/custom/bar.yaml
+   description: 'Source: Relative path to k3d config file, Destination: Magic shortcut path, Description: Defined'
+ - source: baz-ns.yaml
+   destination: k3s-manifests-custom/baz-server.yaml # Resolved to /var/lib/rancher/k3s/server/manifests/custom/bar-server.yaml
+   nodeFilters:
+   - "server:*"
+   description: 'Source: Relative path to k3d config file, Destination: Magic shortcut path, Node: Defined, Description: Defined'
 
 options:
   k3d:

--- a/pkg/config/transform.go
+++ b/pkg/config/transform.go
@@ -47,7 +47,7 @@ import (
 )
 
 // TransformSimpleToClusterConfig transforms a simple configuration to a full-fledged cluster configuration
-func TransformSimpleToClusterConfig(ctx context.Context, runtime runtimes.Runtime, simpleConfig conf.SimpleConfig) (*conf.ClusterConfig, error) {
+func TransformSimpleToClusterConfig(ctx context.Context, runtime runtimes.Runtime, simpleConfig conf.SimpleConfig, configFileName string) (*conf.ClusterConfig, error) {
 	// set default cluster name
 	if simpleConfig.Name == "" {
 		simpleConfig.Name = k3d.DefaultClusterName
@@ -381,6 +381,35 @@ func TransformSimpleToClusterConfig(ctx context.Context, runtime runtimes.Runtim
 
 		l.Log().Tracef("Registry: read config from input:\n%+v", k3sRegistry)
 		clusterCreateOpts.Registries.Config = k3sRegistry
+	}
+
+	/*
+	 * Files
+	 */
+
+	for _, fileWithNodeFilters := range simpleConfig.Files {
+		nodes, err := util.FilterNodes(nodeList, fileWithNodeFilters.NodeFilters)
+		if err != nil {
+			return nil, fmt.Errorf("failed to filter nodes for file copying '%s': %w", fileWithNodeFilters, err)
+		}
+
+		content, err := util.ReadFileSource(configFileName, fileWithNodeFilters.Source)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read source content: %w", err)
+		}
+
+		destination, err := util.ResolveFileDestination(fileWithNodeFilters.Destination)
+		if err != nil {
+			return nil, fmt.Errorf("destination path is not correct: %w", err)
+		}
+
+		for _, node := range nodes {
+			node.Files = append(node.Files, k3d.File{
+				Content:     content,
+				Destination: destination,
+				Description: fileWithNodeFilters.Description,
+			})
+		}
 	}
 
 	/**********************

--- a/pkg/config/v1alpha5/schema.json
+++ b/pkg/config/v1alpha5/schema.json
@@ -114,6 +114,28 @@
         "additionalProperties": false
       }
     },
+    "files": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["source", "destination"],
+        "properties": {
+          "source": {
+            "type": "string"
+          },
+          "destination": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "nodeFilters": {
+            "$ref": "#/definitions/nodeFilters"
+          }
+        },
+        "additionalProperties": false
+      }
+    },
     "options": {
       "type": "object",
       "properties": {

--- a/pkg/config/v1alpha5/types.go
+++ b/pkg/config/v1alpha5/types.go
@@ -83,6 +83,13 @@ type K3sArgWithNodeFilters struct {
 	NodeFilters []string `mapstructure:"nodeFilters" json:"nodeFilters,omitempty"`
 }
 
+type FileWithNodeFilters struct {
+	Source      string   `mapstructure:"source" json:"source,omitempty"`
+	Destination string   `mapstructure:"destination" json:"destination,omitempty"`
+	Description string   `mapstructure:"description" json:"description,omitempty"`
+	NodeFilters []string `mapstructure:"nodeFilters" json:"nodeFilters,omitempty"`
+}
+
 type SimpleConfigRegistryCreateConfig struct {
 	Name     string            `mapstructure:"name" json:"name,omitempty"`
 	Host     string            `mapstructure:"host" json:"host,omitempty"`
@@ -162,6 +169,7 @@ type SimpleConfig struct {
 	Env               []EnvVarWithNodeFilters `mapstructure:"env" json:"env,omitempty"`
 	Registries        SimpleConfigRegistries  `mapstructure:"registries" json:"registries,omitempty"`
 	HostAliases       []k3d.HostAlias         `mapstructure:"hostAliases" json:"hostAliases,omitempty"`
+	Files             []FileWithNodeFilters   `mapstructure:"files" json:"files,omitempty"`
 }
 
 // SimpleExposureOpts provides a simplified syntax compared to the original k3d.ExposureOpts

--- a/pkg/types/files.go
+++ b/pkg/types/files.go
@@ -1,5 +1,5 @@
 /*
-Copyright © 2020-2023 The k3d Author(s)
+Copyright © 2020-2024 The k3d Author(s)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -19,36 +19,10 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
+package types
 
-package config
-
-import (
-	"context"
-	"testing"
-
-	conf "github.com/k3d-io/k3d/v5/pkg/config/v1alpha5"
-	"github.com/k3d-io/k3d/v5/pkg/runtimes"
-	"github.com/spf13/viper"
-)
-
-func TestTransformSimpleConfigToClusterConfig(t *testing.T) {
-	cfgFile := "./test_assets/config_test_simple.yaml"
-
-	vip := viper.New()
-	vip.SetConfigFile(cfgFile)
-	_ = vip.ReadInConfig()
-
-	cfg, err := FromViper(vip)
-	if err != nil {
-		t.Error(err)
-	}
-
-	t.Logf("\n========== Read Config ==========\n%+v\n=================================\n", cfg)
-
-	clusterCfg, err := TransformSimpleToClusterConfig(context.Background(), runtimes.Docker, cfg.(conf.SimpleConfig), cfgFile)
-	if err != nil {
-		t.Error(err)
-	}
-
-	t.Logf("\n===== Resulting Cluster Config =====\n%+v\n===============\n", clusterCfg)
+type File struct {
+	Content     []byte `mapstructure:"content" json:"content,omitempty"`
+	Destination string `mapstructure:"destination" json:"destination,omitempty"`
+	Description string `mapstructure:"description" json:"description,omitempty"`
 }

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -291,6 +291,7 @@ type Node struct {
 	Env            []string              `json:"env,omitempty"`
 	Cmd            []string              // filled automatically based on role
 	Args           []string              `json:"extraArgs,omitempty"`
+	Files          []File                `json:"files,omitempty"`
 	Ports          nat.PortMap           `json:"portMappings,omitempty"`
 	Restart        bool                  `json:"restart,omitempty"`
 	Created        string                `json:"created,omitempty"`


### PR DESCRIPTION
# What

This PR introduces embedded manifests in the k3d config file which boosts the portability of the config and makes it easier to share.

So adding an embedded manifest could be as easy as:

```yaml
apiVersion: k3d.io/v1alpha5
kind: Simple
metadata:
  name: my-app

manifests:
  - name: my-app-ns.yaml
    manifest: |
      ---
      apiVersion: v1
      kind: Namespace
      metadata:
        name: my-app
```

This will be mounted under: `/var/lib/rancher/k3s/server/manifests/embedded/my-app-ns.yaml`.

# Why

In addition to the portability, the goal is to make it easy to seed k3d resources, and given that k3s already supports [HelmChart](https://docs.k3s.io/helm) it will be even easier to pre-install any custom packages when the cluster is created.

Fixes https://github.com/k3d-io/k3d/issues/536
Also partially fixes https://github.com/k3d-io/k3d/issues/1065 since no need to be in the same dir to mount some seed manifests.

# Implications

No expected change in the behavior.

> [!NOTE]
> The CLI part is not done yet, I will do it once we agree on the implementation.

Thank you 🙌