### PR TITLE
Add nginx DNS expiration time configuration

### DIFF
--- a/proxy/templates/nginx.tmpl
+++ b/proxy/templates/nginx.tmpl
@@ -15,6 +15,7 @@ events {
 }
 
 stream {
+  resolver 127.0.0.11 valid=10s;
 
   {{- range $portstring := lsdir "/ports" }}
 


### PR DESCRIPTION
# What

Add a shorter DNS expiration time to avoid inaccessibility caused by IP address changes when the node container is restarted.

# Why

When the node container is restarted or the docker service is restarted, the node IP may change, but nginx will cache the IP of the node domain name, causing the reverse proxy to fail.

# Implications

Since the cache time is shortened, it will have a slight impact on the performance of the nginx reverse proxy, so you don't need to worry about it.
