### PR TITLE
fix: close output file

### DIFF
--- a/cmd/config/configInit.go
+++ b/cmd/config/configInit.go
@@ -53,6 +53,7 @@ func NewCmdConfigInit() *cobra.Command {
 					if err != nil {
 						l.Log().Fatalf("Failed to create/overwrite output file: %s", err)
 					}
+					defer file.Close()
 					// write content
 					if _, err = file.WriteString(config.DefaultConfig); err != nil {
 						l.Log().Fatalf("Failed to write to output file: %+v", err)


### PR DESCRIPTION
<!-- 
Hi there, have an early THANK YOU for your contribution!
k3d is a community-driven project, so we really highly appreciate any support.
Please make sure, you've read our Code of Conduct and the Contributing Guidelines :)
- Code of Conduct: https://github.com/k3d-io/k3d/blob/main/CODE_OF_CONDUCT.md
- Contributing Guidelines: https://github.com/k3d-io/k3d/blob/main/CONTRIBUTING.md
-->

# What

<!-- What does this PR do or change? -->

# Why

<!-- Link issues, discussions, etc. or just explain why you're creating this PR -->

# Implications

<!--
Does this change existing behavior? If so, does it affect the CLI (cmd/) only or does it also/only change some internals of the Go module (pkg/)?
Especially mention breaking changes here!
-->

<!-- Get recognized using our all-contributors bot: https://github.com/k3d-io/k3d/blob/main/CONTRIBUTING.md#get-recognized -->
