### PR TITLE
fix: Script exits fatally when resolv.conf is missing Docker nameserver

### DIFF
--- a/pkg/types/fixes/assets/k3d-entrypoint-dns.sh
+++ b/pkg/types/fixes/assets/k3d-entrypoint-dns.sh
@@ -23,9 +23,7 @@ iptables-save \
   | iptables-restore
 
 # Update resolv.conf to use the Gateway IP if needed: this will also make CoreDNS use it via k3s' default `forward . /etc/resolv.conf` rule in the CoreDNS config
-grep -q "${docker_dns}" /etc/resolv.conf
-grepstatus=$?
-if test $grepstatus -eq 0; then
+if grep -q "${docker_dns}" /etc/resolv.conf; then
   echo "[$(date -Iseconds)] [DNS Fix] > Replacing IP in /etc/resolv.conf ..."
   cp /etc/resolv.conf /etc/resolv.conf.original
   sed -e "s/${docker_dns}/${gateway}/g" /etc/resolv.conf.original >/etc/resolv.conf


### PR DESCRIPTION
<!-- 
Hi there, have an early THANK YOU for your contribution!
k3d is a community-driven project, so we really highly appreciate any support.
Please make sure, you've read our Code of Conduct and the Contributing Guidelines :)
- Code of Conduct: https://github.com/k3d-io/k3d/blob/main/CODE_OF_CONDUCT.md
- Contributing Guidelines: https://github.com/k3d-io/k3d/blob/main/CONTRIBUTING.md
-->

# What

<!-- What does this PR do or change? -->

Fixes the use of the `grep` command causing an early fatal exit of the shell script.

# Why

<!-- Link issues, discussions, etc. or just explain why you're creating this PR -->

In non-Docker and host network environments, this `grep -q` will be fatal and because `-o errexit` is set, the shell script will exit fatally causing the k3s server to fail.

# Implications

<!--
Does this change existing behavior? If so, does it affect the CLI (cmd/) only or does it also/only change some internals of the Go module (pkg/)?
Especially mention breaking changes here!
-->

<!-- Get recognized using our all-contributors bot: https://github.com/k3d-io/k3d/blob/main/CONTRIBUTING.md#get-recognized -->
