### PR TITLE
feat: compatibility with docker userns-remap

### DIFF
--- a/pkg/runtimes/docker/translate.go
+++ b/pkg/runtimes/docker/translate.go
@@ -127,6 +127,9 @@ func TranslateNodeToContainer(node *k3d.Node) (*NodeInDocker, error) {
 	// TODO: can we replace this by a reduced set of capabilities?
 	hostConfig.Privileged = true
 
+	// Privileged containers require userns=host when Docker has userns-remap enabled
+	hostConfig.UsernsMode = "host"
+
 	if node.HostPidMode {
 		hostConfig.PidMode = "host"
 	}


### PR DESCRIPTION
# What

This MR make k3d compatible with the [userns-remap](https://docs.docker.com/engine/security/userns-remap/) feature of Docker, like described in [#547](https://github.com/k3d-io/k3d/issues/547).

# Why

As a developer, I run container applications from various sources and some run as root in the container.
To strengthen the isolation between the host and the containers, Im interested in leveraging Linux user namespaces.

Here's an example of a security exploit that would be blocked by using user namespaces, according to one of the maintainers of runc:  [CVE-2019-5736](https://seclists.org/oss-sec/2019/q1/119) 

Docker supports user namespaces when the daemon is configured to run with userns-remap.
With this setting enabled, privileged containers need to be created with `userns=host` explicitly.

# Implications

This MR just set `userns=host` on all K3d privileged containers. As far as I understand, having a mechanism to detect if the daemon has userns-remap enabled is useless:
- when userns-remap is disabled, the containers share the user namespace with the host, so setting `userns=host` has virtually no impact
- when userns-remap is enabled, `userns=host` is required to start node containers

So it should be transparent for users who have userns-remap disabled. (Am I missing something?)

# Tests

I've run this branch of k3d on my daily development laptop with no issue for a week now. 
I have Localstack, Prometheus, Loki and Grafana deployed via Helm, with values suitable for single-node/development deployment.
