### PR TITLE
test: fix TestTranslateNodeToContainer following #1442

### DIFF
--- a/pkg/runtimes/docker/translate_test.go
+++ b/pkg/runtimes/docker/translate_test.go
@@ -81,6 +81,7 @@ func TestTranslateNodeToContainer(t *testing.T) {
 			},
 			Init:       &init,
 			Privileged: true,
+			UsernsMode: "host",
 			Tmpfs:      map[string]string{"/run": "", "/var/run": ""},
 			PortBindings: nat.PortMap{
 				"6443/tcp": {


### PR DESCRIPTION
# What

This MR updates the expectation of TestTranslateNodeToContainer

# Why

https://github.com/k3d-io/k3d/pull/1442 broke the test, my apologies.

# Implications

None AFAICT
