### PR TITLE
Allow config and pre-processed configuration to leverage environment variables

### DIFF
--- a/cmd/cluster/clusterDelete.go
+++ b/cmd/cluster/clusterDelete.go
@@ -26,6 +26,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"strings"
 
 	"github.com/k3d-io/k3d/v5/cmd/util"
 	cliconfig "github.com/k3d-io/k3d/v5/cmd/util/config"
@@ -35,13 +36,31 @@ import (
 	"github.com/k3d-io/k3d/v5/pkg/runtimes"
 	k3d "github.com/k3d-io/k3d/v5/pkg/types"
 	k3dutil "github.com/k3d-io/k3d/v5/pkg/util"
+	"github.com/sirupsen/logrus"
+	"sigs.k8s.io/yaml"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
 
-var clusterDeleteConfigFile string
-var clusterDeleteCfgViper = viper.New()
+var (
+	clusterDeleteCfgViper = viper.New()
+	clusterDeletePpViper  = viper.New()
+)
+
+func initClusterDeleteConfig() error {
+	// Viper for pre-processed config options
+	ppViper.SetEnvPrefix("K3D")
+	ppViper.AutomaticEnv()
+	ppViper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
+
+	if l.Log().GetLevel() >= logrus.DebugLevel {
+		c, _ := yaml.Marshal(ppViper.AllSettings())
+		l.Log().Debugf("Additional CLI Configuration:\n%s", c)
+	}
+
+	return cliconfig.InitViperWithConfigFile(cfgViper, ppViper.GetString("config"))
+}
 
 // NewCmdClusterDelete returns a new cobra command
 func NewCmdClusterDelete() *cobra.Command {
@@ -54,7 +73,7 @@ func NewCmdClusterDelete() *cobra.Command {
 		Args:              cobra.MinimumNArgs(0), // 0 or n arguments; 0 = default cluster name
 		ValidArgsFunction: util.ValidArgsAvailableClusters,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return cliconfig.InitViperWithConfigFile(clusterDeleteCfgViper, clusterDeleteConfigFile)
+			return initClusterDeleteConfig()
 		},
 		Run: func(cmd *cobra.Command, args []string) {
 			clusters := parseDeleteClusterCmd(cmd, args)
@@ -99,7 +118,8 @@ func NewCmdClusterDelete() *cobra.Command {
 	 * Config File *
 	 ***************/
 
-	cmd.Flags().StringVarP(&clusterDeleteConfigFile, "config", "c", "", "Path of a config file to use")
+	cmd.Flags().StringP("config", "c", "", "Path of a config file to use")
+	_ = ppViper.BindPFlag("config", cmd.Flags().Lookup("config"))
 	if err := cmd.MarkFlagFilename("config", "yaml", "yml"); err != nil {
 		l.Log().Fatalln("Failed to mark flag 'config' as filename flag")
 	}
@@ -119,7 +139,7 @@ func parseDeleteClusterCmd(cmd *cobra.Command, args []string) []*k3d.Cluster {
 	}
 
 	// --config
-	if clusterDeleteConfigFile != "" {
+	if clusterDeletePpViper.GetString("config") != "" {
 		// not allowed with --all or more args
 		if len(args) > 0 || all {
 			l.Log().Fatalln("failed to delete cluster: cannot use `--config` flag with additional arguments or `--all`")


### PR DESCRIPTION
# What

Currently, there are a few command line arguments for `cluster create` and `cluster delete` that cannot be specified using environment variables. This PR tries to address this by leveraging `viper`, which is already being used by `k3d`.

# Why

I'd like to set a default configuration for `k3d`, and the easiest way would be to have `K3D_CONFIG=${HOME}/.k3d/config.yaml` in my shell environment.

Another approach could have been to use `viper` configuration loading mechanism (which has a mechanism to locate configuration files from various locations) but it would have been a more involving change.

# Implications

I don't think there are any, as the change is relatively minor and backward compatible.

<!-- Get recognized using our all-contributors bot: https://github.com/k3d-io/k3d/blob/main/CONTRIBUTING.md#get-recognized -->
