### PR TITLE
fix: preserve coredns config during cluster restart

### DIFF
--- a/pkg/client/cluster.go
+++ b/pkg/client/cluster.go
@@ -1051,26 +1051,33 @@ func ClusterStart(ctx context.Context, runtime k3drt.Runtime, cluster *k3d.Clust
 			// -> inject hostAliases and network members into CoreDNS configmap
 			if len(servers) > 0 {
 				postStartErrgrp.Go(func() error {
+					type record struct {
+						IP       string
+						Hostname string
+					}
+
+					records := make([]record, 0)
+
+					// hosts: hostAliases (including host.k3d.internal)
+					for _, hostAlias := range clusterStartOpts.HostAliases {
+						for _, hostname := range hostAlias.Hostnames {
+							records = append(records, record{IP: hostAlias.IP, Hostname: hostname})
+						}
+					}
+
+					// more hosts: network members ("neighbor" containers)
 					net, err := runtime.GetNetwork(postStartErrgrpCtx, &cluster.Network)
 					if err != nil {
 						return fmt.Errorf("failed to get cluster network %s to inject host records into CoreDNS: %w", cluster.Network.Name, err)
 					}
-					hosts := make([]string, 0, len(net.Members)+1)
-
-					// hosts: hostAliases (including host.k3d.internal)
-					for _, hostAlias := range clusterStartOpts.HostAliases {
-						hosts = append(hosts, fmt.Sprintf("%s %s\n", hostAlias.IP, strings.Join(hostAlias.Hostnames, " ")))
-					}
-
-					// more hosts: network members ("neighbor" containers)
 					for _, member := range net.Members {
-						hosts = append(hosts, fmt.Sprintf("%s %s\n", member.IP.String(), member.Name))
+						records = append(records, record{IP: member.IP.String(), Hostname: member.Name})
 					}
 
 					// inject CoreDNS configmap
 					l.Log().Infof("Injecting records for hostAliases (incl. host.k3d.internal) and for %d network members into CoreDNS configmap...", len(net.Members))
 					var custom_dns bytes.Buffer
-					err = customDNSTemplate.Execute(&custom_dns, hosts)
+					err = customDNSTemplate.Execute(&custom_dns, records)
 					if err != nil {
 						return fmt.Errorf("failed to render template: %w", err)
 					}

--- a/pkg/client/cluster.go
+++ b/pkg/client/cluster.go
@@ -31,6 +31,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"text/template"
 	"time"
 
 	"github.com/docker/go-connections/nat"
@@ -53,6 +54,10 @@ import (
 	"github.com/k3d-io/k3d/v5/pkg/util"
 	goyaml "gopkg.in/yaml.v2"
 )
+
+//go:embed templates/coredns-custom.yaml.tmpl
+var customDNSTemplateStr string
+var customDNSTemplate = template.Must(template.New("customDNS").Parse(customDNSTemplateStr))
 
 // ClusterRun orchestrates the steps of cluster creation, configuration and starting
 func ClusterRun(ctx context.Context, runtime k3drt.Runtime, clusterConfig *config.ClusterConfig) error {
@@ -1046,58 +1051,34 @@ func ClusterStart(ctx context.Context, runtime k3drt.Runtime, cluster *k3d.Clust
 			// -> inject hostAliases and network members into CoreDNS configmap
 			if len(servers) > 0 {
 				postStartErrgrp.Go(func() error {
-					hosts := ""
-
-					// hosts: hostAliases (including host.k3d.internal)
-					for _, hostAlias := range clusterStartOpts.HostAliases {
-						hosts += fmt.Sprintf("%s %s\n", hostAlias.IP, strings.Join(hostAlias.Hostnames, " "))
-					}
-
-					// more hosts: network members ("neighbor" containers)
 					net, err := runtime.GetNetwork(postStartErrgrpCtx, &cluster.Network)
 					if err != nil {
 						return fmt.Errorf("failed to get cluster network %s to inject host records into CoreDNS: %w", cluster.Network.Name, err)
 					}
+					hosts := make([]string, 0, len(net.Members)+1)
+
+					// hosts: hostAliases (including host.k3d.internal)
+					for _, hostAlias := range clusterStartOpts.HostAliases {
+						hosts = append(hosts, fmt.Sprintf("%s %s\n", hostAlias.IP, strings.Join(hostAlias.Hostnames, " ")))
+					}
+
+					// more hosts: network members ("neighbor" containers)
 					for _, member := range net.Members {
-						hosts += fmt.Sprintf("%s %s\n", member.IP.String(), member.Name)
+						hosts = append(hosts, fmt.Sprintf("%s %s\n", member.IP.String(), member.Name))
 					}
 
 					// inject CoreDNS configmap
 					l.Log().Infof("Injecting records for hostAliases (incl. host.k3d.internal) and for %d network members into CoreDNS configmap...", len(net.Members))
-					act := actions.RewriteFileAction{
+					var custom_dns bytes.Buffer
+					err = customDNSTemplate.Execute(&custom_dns, hosts)
+					if err != nil {
+						return fmt.Errorf("failed to render template: %w", err)
+					}
+					act := actions.WriteFileAction{
 						Runtime: runtime,
-						Path:    "/var/lib/rancher/k3s/server/manifests/coredns.yaml",
+						Content: []byte(custom_dns.Bytes()),
+						Dest:    "/var/lib/rancher/k3s/server/manifests/coredns-custom.yaml",
 						Mode:    0744,
-						RewriteFunc: func(input []byte) ([]byte, error) {
-							split, err := util.SplitYAML(input)
-							if err != nil {
-								return nil, fmt.Errorf("error splitting yaml: %w", err)
-							}
-
-							var outputBuf bytes.Buffer
-							outputEncoder := util.NewYAMLEncoder(&outputBuf)
-
-							for _, d := range split {
-								var doc map[string]interface{}
-								if err := yaml.Unmarshal(d, &doc); err != nil {
-									return nil, err
-								}
-								if kind, ok := doc["kind"]; ok {
-									if strings.ToLower(kind.(string)) == "configmap" {
-										configmapData, ok := doc["data"].(map[string]interface{})
-										if !ok {
-											return nil, fmt.Errorf("invalid ConfigMap data type: %T", doc["data"])
-										}
-										configmapData["NodeHosts"] = hosts
-									}
-								}
-								if err := outputEncoder.Encode(doc); err != nil {
-									return nil, err
-								}
-							}
-							_ = outputEncoder.Close()
-							return outputBuf.Bytes(), nil
-						},
 					}
 
 					// get the first server in the list and run action on it once it's ready for it

--- a/pkg/client/templates/coredns-custom.yaml.tmpl
+++ b/pkg/client/templates/coredns-custom.yaml.tmpl
@@ -5,9 +5,11 @@ metadata:
   namespace: kube-system
 data:
   hosts.override: |
-    hosts {
-        {{- range . }}
-        {{ . }}
-        {{- end }}
-        fallthrough
-    }
+    file /etc/coredns/custom/additional-dns.db
+  
+  # a SOA record is required
+  additional-dns.db: |
+    @ 3600 IN SOA a.root-servers.net. nstld.verisign-grs.com. 2024061200 1800 900 604800 86400
+    {{- range . }}
+    {{ .Hostname }} IN A {{ .IP }}
+    {{- end }}

--- a/pkg/client/templates/coredns-custom.yaml.tmpl
+++ b/pkg/client/templates/coredns-custom.yaml.tmpl
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: coredns-custom
+  namespace: kube-system
+data:
+  hosts.override: |
+    hosts {
+        {{- range . }}
+        {{ . }}
+        {{- end }}
+        fallthrough
+    }


### PR DESCRIPTION
<!-- 
Hi there, have an early THANK YOU for your contribution!
k3d is a community-driven project, so we really highly appreciate any support.
Please make sure, you've read our Code of Conduct and the Contributing Guidelines :)
- Code of Conduct: https://github.com/k3d-io/k3d/blob/main/CODE_OF_CONDUCT.md
- Contributing Guidelines: https://github.com/k3d-io/k3d/blob/main/CONTRIBUTING.md
-->

# What
fixes #1221

<!-- What does this PR do or change? -->

# Why
Since `coredns` configmap will be reverted to original state during k3s startup process, this PR utilizes `coredns-custom` configmap (introduced in k3s-io/k3s#4397) to persistent custom coredns configs (e.g. the `host.k3d.internal` record).

Since coredns's `host` plugin can only be used once per server block, I have to use the `file` plugin.

A go template is used to render the configmap. I don't know if there's a better way.

<!-- Link issues, discussions, etc. or just explain why you're creating this PR -->

# Implications
Not I'm aware of.
<!--
Does this change existing behavior? If so, does it affect the CLI (cmd/) only or does it also/only change some internals of the Go module (pkg/)?
Especially mention breaking changes here!
-->

<!-- Get recognized using our all-contributors bot: https://github.com/k3d-io/k3d/blob/main/CONTRIBUTING.md#get-recognized -->
