### PR TITLE
runtimes: enable log export feature

### DIFF
--- a/cmd/cluster/cluster.go
+++ b/cmd/cluster/cluster.go
@@ -48,7 +48,8 @@ func NewCmdCluster() *cobra.Command {
 		NewCmdClusterStop(),
 		NewCmdClusterDelete(),
 		NewCmdClusterList(),
-		NewCmdClusterEdit())
+		NewCmdClusterEdit(),
+	)
 
 	// add flags
 

--- a/cmd/node/node.go
+++ b/cmd/node/node.go
@@ -47,7 +47,8 @@ func NewCmdNode() *cobra.Command {
 		NewCmdNodeStop(),
 		NewCmdNodeDelete(),
 		NewCmdNodeList(),
-		NewCmdNodeEdit())
+		NewCmdNodeEdit(),
+	)
 
 	// add flags
 

--- a/pkg/runtimes/docker/docker.go
+++ b/pkg/runtimes/docker/docker.go
@@ -29,6 +29,7 @@ import (
 	"os"
 
 	l "github.com/k3d-io/k3d/v5/pkg/logger"
+	k3d "github.com/k3d-io/k3d/v5/pkg/types"
 )
 
 type Docker struct{}
@@ -40,6 +41,32 @@ const (
 // ID returns the identity of the runtime
 func (d Docker) ID() string {
 	return "docker"
+}
+
+type commandInfo struct {
+	Command  []string
+	FileName string
+}
+
+var roleBasedExportPath = map[k3d.Role][]string{
+	k3d.ServerRole: {"/var/log", "/var/lib/rancher/k3s/agent/containerd/containerd.log"},
+	k3d.AgentRole:  {"/var/log", "/var/lib/rancher/k3s/agent/containerd/containerd.log"},
+}
+
+var roleBasedCommandsToExecute = map[k3d.Role][]commandInfo{
+	k3d.ServerRole: {
+		{Command: []string{"crictl", "images"}, FileName: "crictl-images.log"},
+		{Command: []string{"crictl", "ps", "-a"}, FileName: "crictl-ps.log"},
+		{Command: []string{"kubectl", "cluster-info"}, FileName: "cluster-info.log"},
+		{Command: []string{"kubectl", "version"}, FileName: "kubectl-version.log"},
+		{Command: []string{"kubectl", "get", "node", "-o", "yaml"}, FileName: "kubectl-get-node.yaml"},
+		{Command: []string{"ps", "-aef"}, FileName: "ps-aef.log"},
+	},
+	k3d.AgentRole: {
+		{Command: []string{"crictl", "images"}, FileName: "crictl-images.log"},
+		{Command: []string{"crictl", "ps", "-a"}, FileName: "crictl-ps.log"},
+		{Command: []string{"ps", "-aef"}, FileName: "ps-aef.log"},
+	},
 }
 
 // GetHost returns the docker daemon host

--- a/pkg/runtimes/runtime.go
+++ b/pkg/runtimes/runtime.go
@@ -81,6 +81,7 @@ type Runtime interface {
 	DisconnectNodeFromNetwork(context.Context, *k3d.Node, string) error // @param context, node, network name
 	Info() (*runtimeTypes.RuntimeInfo, error)
 	GetNetwork(context.Context, *k3d.ClusterNetwork) (*k3d.ClusterNetwork, error) // @param context, network (so we can filter by name or by id)
+	ExportLogsFromNode(context.Context, *k3d.Node, string, []string) error        // @param context, node, source, destination, components (This is meant for future use once we identify what/how to filter)
 }
 
 // GetRuntime checks, if a given name is represented by an implemented k3d runtime and returns it


### PR DESCRIPTION
# What

This feature adds an ability to export Cluster logs using the `k3d` binaries.

# Why

Tools like `kind` has been supporting the ability to export logs from the cluster using their native tooling for a while. This ability to export the logs using `k3d` can be super helpful when doing local development and test experiments. Instead of having to individually collect the logs, this command can be one stop shop for all standard commands to be aggregated. 

# Implications

This changes the `Runtime` interface and hence this is a backward incompatible change. 

> If this is an acceptable change to be included, I will be more than happy to take care of including a few more things to the supported export of logs. 

```bash
❯ bin/k3d debug export-logs export-log-test
❯ tree debug-logs-export-log-test/
debug-logs-export-log-test/
├── k3d-export-log-test-server-0
│   ├── cluster-info.log
│   ├── containerd.log
│   ├── crictl-images.log
│   ├── crictl-ps.log
│   ├── kubectl-get-node.yaml
│   ├── kubectl-version.log
│   ├── log
│   │   ├── containers
│   │   │   ├── coredns-7448499f4d-62f57_kube-system_coredns-b66d5470354351c562ee3f3f2edbff20d117e294549e0e92836a81b61ab71978.log
│   │   │   ├── helm-install-traefik-44sht_kube-system_helm-14c069fc9a9bb06878083cbff48a68138852eaa283d605b1d2d51dad3ef94814.log
│   │   │   ├── helm-install-traefik-crd-fh29n_kube-system_helm-63fbaed67883b443593f803fea47c2d60fe42311ebfd7fbe2f9a2a3dd4ec4b91.log
│   │   │   ├── local-path-provisioner-5ff76fc89d-m5wz6_kube-system_local-path-provisioner-ebde80834fa702282e3c0f1ee871172a3690e27c55c39c884b1e23cb09b94d15.log
│   │   │   ├── metrics-server-86cbb8457f-lg7tq_kube-system_metrics-server-b16a150d61faa07a257db24758b95807ec131f08d4006eb1dbe7970e1145020c.log
│   │   │   ├── svclb-traefik-hst27_kube-system_lb-port-443-bdb21890b8d32bcffb1cfacd12a157ea0d73cde672dbea703279166dafa49ebf.log
│   │   │   ├── svclb-traefik-hst27_kube-system_lb-port-80-6d1cfb81abf4a5573998d49a00621a03d9fe05c7f18033bf59f4e412905a8be6.log
│   │   │   └── traefik-6b84f7cbc-l574b_kube-system_traefik-bd236ceb3ef60e87e3495afc039ad2f2dacc628c1f9c056d11dd9a137ac7642a.log
│   │   ├── k3d-entrypoints_250117074528.log
│   │   └── pods
│   │       ├── kube-system_coredns-7448499f4d-62f57_0a9c8c5a-594f-468a-9c6a-b8b9c8db6875
│   │       │   └── coredns
│   │       │       └── 0.log
│   │       ├── kube-system_helm-install-traefik-44sht_59ef59f1-a663-46f9-9e7b-166bc0091e5b
│   │       │   └── helm
│   │       │       └── 2.log
│   │       ├── kube-system_helm-install-traefik-crd-fh29n_10a82388-d43f-474c-b8c2-867c510fd1cb
│   │       │   └── helm
│   │       │       └── 0.log
│   │       ├── kube-system_local-path-provisioner-5ff76fc89d-m5wz6_bc459eed-fdc3-4c9d-85b6-d26703ac4881
│   │       │   └── local-path-provisioner
│   │       │       └── 0.log
│   │       ├── kube-system_metrics-server-86cbb8457f-lg7tq_01ee3bec-bf2a-405b-9232-96ccd203f3af
│   │       │   └── metrics-server
│   │       │       └── 0.log
│   │       ├── kube-system_svclb-traefik-hst27_ae354af9-c674-49c7-96af-9d17634b90fd
│   │       │   ├── lb-port-443
│   │       │   │   └── 0.log
│   │       │   └── lb-port-80
│   │       │       └── 0.log
│   │       └── kube-system_traefik-6b84f7cbc-l574b_1aa62a25-4d5f-439c-9465-09dfb1a825f9
│   │           └── traefik
│   │               └── 0.log
│   └── ps-aef.log
├── k3d-export-log-test-server-0.log
├── k3d-export-log-test-serverlb
└── k3d-export-log-test-serverlb.log

21 directories, 26 files
```
```bash
❯ bin/k3d debug export-logs export-log-test --node k3d-export-log-test-server-0
❯ tree debug-logs-export-log-test/
debug-logs-export-log-test/
├── k3d-export-log-test-server-0
│   ├── cluster-info.log
│   ├── containerd.log
│   ├── crictl-images.log
│   ├── crictl-ps.log
│   ├── kubectl-get-node.yaml
│   ├── kubectl-version.log
│   ├── log
│   │   ├── containers
│   │   │   ├── coredns-7448499f4d-62f57_kube-system_coredns-b66d5470354351c562ee3f3f2edbff20d117e294549e0e92836a81b61ab71978.log
│   │   │   ├── helm-install-traefik-44sht_kube-system_helm-14c069fc9a9bb06878083cbff48a68138852eaa283d605b1d2d51dad3ef94814.log
│   │   │   ├── helm-install-traefik-crd-fh29n_kube-system_helm-63fbaed67883b443593f803fea47c2d60fe42311ebfd7fbe2f9a2a3dd4ec4b91.log
│   │   │   ├── local-path-provisioner-5ff76fc89d-m5wz6_kube-system_local-path-provisioner-ebde80834fa702282e3c0f1ee871172a3690e27c55c39c884b1e23cb09b94d15.log
│   │   │   ├── metrics-server-86cbb8457f-lg7tq_kube-system_metrics-server-b16a150d61faa07a257db24758b95807ec131f08d4006eb1dbe7970e1145020c.log
│   │   │   ├── svclb-traefik-hst27_kube-system_lb-port-443-bdb21890b8d32bcffb1cfacd12a157ea0d73cde672dbea703279166dafa49ebf.log
│   │   │   ├── svclb-traefik-hst27_kube-system_lb-port-80-6d1cfb81abf4a5573998d49a00621a03d9fe05c7f18033bf59f4e412905a8be6.log
│   │   │   └── traefik-6b84f7cbc-l574b_kube-system_traefik-bd236ceb3ef60e87e3495afc039ad2f2dacc628c1f9c056d11dd9a137ac7642a.log
│   │   ├── k3d-entrypoints_250117074528.log
│   │   └── pods
│   │       ├── kube-system_coredns-7448499f4d-62f57_0a9c8c5a-594f-468a-9c6a-b8b9c8db6875
│   │       │   └── coredns
│   │       │       └── 0.log
│   │       ├── kube-system_helm-install-traefik-44sht_59ef59f1-a663-46f9-9e7b-166bc0091e5b
│   │       │   └── helm
│   │       │       └── 2.log
│   │       ├── kube-system_helm-install-traefik-crd-fh29n_10a82388-d43f-474c-b8c2-867c510fd1cb
│   │       │   └── helm
│   │       │       └── 0.log
│   │       ├── kube-system_local-path-provisioner-5ff76fc89d-m5wz6_bc459eed-fdc3-4c9d-85b6-d26703ac4881
│   │       │   └── local-path-provisioner
│   │       │       └── 0.log
│   │       ├── kube-system_metrics-server-86cbb8457f-lg7tq_01ee3bec-bf2a-405b-9232-96ccd203f3af
│   │       │   └── metrics-server
│   │       │       └── 0.log
│   │       ├── kube-system_svclb-traefik-hst27_ae354af9-c674-49c7-96af-9d17634b90fd
│   │       │   ├── lb-port-443
│   │       │   │   └── 0.log
│   │       │   └── lb-port-80
│   │       │       └── 0.log
│   │       └── kube-system_traefik-6b84f7cbc-l574b_1aa62a25-4d5f-439c-9465-09dfb1a825f9
│   │           └── traefik
│   │               └── 0.log
│   └── ps-aef.log
└── k3d-export-log-test-server-0.log

20 directories, 25 files
