### PR TITLE
fix: bump base image of k3d-proxy to resolve vulnerabilities.

### DIFF
--- a/proxy/Dockerfile
+++ b/proxy/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:1.25.1-alpine3.17
+FROM nginx:1.26.1-alpine3.19
 # TODO:_ consider switching to https://github.com/abtreece/confd to not maintain a custom fork anymore
 
 ARG OS


### PR DESCRIPTION
<!-- 
Hi there, have an early THANK YOU for your contribution!
k3d is a community-driven project, so we really highly appreciate any support.
Please make sure, you've read our Code of Conduct and the Contributing Guidelines :)
- Code of Conduct: https://github.com/k3d-io/k3d/blob/main/CODE_OF_CONDUCT.md
- Contributing Guidelines: https://github.com/k3d-io/k3d/blob/main/CONTRIBUTING.md
-->

# What

Bumps the base image of the `k3d-proxy` image to resolve various os package vulnerabilities.

# Why

Resolves all vulnerabilities mentioned in #1472 

# Implications

I was unable to test this locally as of yet on my local machine to validate whether or not it causes any issues, will keep trying and update the ticket once I have validation (debugging local go installation issues with running the make files for this repo). If someone can validate easily and comment on ticket it would be appreciated. 

<!-- Get recognized using our all-contributors bot: https://github.com/k3d-io/k3d/blob/main/CONTRIBUTING.md#get-recognized -->
