### PR TITLE
fix: busybox xargs unlinked on new k3s releases

### DIFF
--- a/pkg/types/fixes/assets/k3d-entrypoint-cgroupv2.sh
+++ b/pkg/types/fixes/assets/k3d-entrypoint-cgroupv2.sh
@@ -11,10 +11,15 @@ set -o nounset
 #########################################################################################################################################
 if [ -f /sys/fs/cgroup/cgroup.controllers ]; then
   echo "[$(date -Iseconds)] [CgroupV2 Fix] Evacuating Root Cgroup ..."
-	# move the processes from the root group to the /init group,
+  # move the processes from the root group to the /init group,
   # otherwise writing subtree_control fails with EBUSY.
   mkdir -p /sys/fs/cgroup/init
-  busybox xargs -rn1 < /sys/fs/cgroup/cgroup.procs > /sys/fs/cgroup/init/cgroup.procs || :
+  # new k3s releases only have xargs from findutils
+  if command -v xargs >/dev/null; then
+    xargs -rn1 </sys/fs/cgroup/cgroup.procs >/sys/fs/cgroup/init/cgroup.procs || :
+  else
+    busybox xargs -rn1 </sys/fs/cgroup/cgroup.procs >/sys/fs/cgroup/init/cgroup.procs || :
+  fi
   # enable controllers
   sed -e 's/ / +/g' -e 's/^/+/' <"/sys/fs/cgroup/cgroup.controllers" >"/sys/fs/cgroup/cgroup.subtree_control"
   echo "[$(date -Iseconds)] [CgroupV2 Fix] Done"


### PR DESCRIPTION

<!-- 
Hi there, have an early THANK YOU for your contribution!
k3d is a community-driven project, so we really highly appreciate any support.
Please make sure, you've read our Code of Conduct and the Contributing Guidelines :)
- Code of Conduct: https://github.com/k3d-io/k3d/blob/main/CODE_OF_CONDUCT.md
- Contributing Guidelines: https://github.com/k3d-io/k3d/blob/main/CONTRIBUTING.md
-->

# What
Fixes server start for recent k3s releases.
<!-- What does this PR do or change? -->

# Why

There was [a change in k3s-root](https://github.com/k3s-io/k3s-root/pull/65), included in k3s 1.30.3-k3s1, which switched to `xargs` from findutils.

<!-- Link issues, discussions, etc. or just explain why you're creating this PR -->

# Implications

The change should be compatible with previous versions of k3s.

# Testing

```
K3D_HELPER_VERSION=5.7.2 make build
./bin/k3d cluster create old --image rancher/k3s:v1.30.2-k3s1
./bin/k3d cluster stop old
./bin/k3d cluster delete old
./bin/k3d cluster create new --image rancher/k3s:v1.30.3-k3s1
./bin/k3d cluster stop new
./bin/k3d cluster delete new
```
<!--
Does this change existing behavior? If so, does it affect the CLI (cmd/) only or does it also/only change some internals of the Go module (pkg/)?
Especially mention breaking changes here!
-->

Fixes #1478

<!-- Get recognized using our all-contributors bot: https://github.com/k3d-io/k3d/blob/main/CONTRIBUTING.md#get-recognized -->
