### PR TITLE
fix: bump docker version in dind image

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,7 +9,7 @@ env:
   IMAGE_BASE_REPO: k3d-io
   IMAGE_PLATFORMS: linux/amd64,linux/arm64,linux/arm/v7
   GO_VERSION: "1.22.x"
-  DOCKER_VERSION: "23.0"
+  DOCKER_VERSION: "27.0"
     
 jobs:
   test-suite:

--- a/.github/workflows/test-matrix.yaml
+++ b/.github/workflows/test-matrix.yaml
@@ -34,10 +34,10 @@ jobs:
       fail-fast: false
       matrix:
         docker_version:
-          - "20.10.5"
-          - "20.10.12"
-          - "20.10.17"
-          - "23.0.1"
+          - "23.0.15"
+          - "25.0.6"
+          - "26.1.5"
+          - "27.3.1"
     steps:
       - uses: actions/checkout@v3
       - name: Setup Docker
@@ -81,11 +81,10 @@ jobs:
       fail-fast: false
       matrix:
         k3s_channel:
-          - "v1.22"
-          - "v1.23"
-          - "v1.24"
-          - "v1.25"
-          - "v1.26"
+          - "v1.28"
+          - "v1.29"
+          - "v1.30"
+          - "v1.31"
     steps:
       - uses: actions/checkout@v3
       - name: Setup Docker

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG DOCKER_VERSION=25.0.3
+ARG DOCKER_VERSION=27.3.1
 ############################################################
 # builder                                                  #
 # -> golang image used solely for building the k3d binary  #


### PR DESCRIPTION
<!-- 
Hi there, have an early THANK YOU for your contribution!
k3d is a community-driven project, so we really highly appreciate any support.
Please make sure, you've read our Code of Conduct and the Contributing Guidelines :)
- Code of Conduct: https://github.com/k3d-io/k3d/blob/main/CODE_OF_CONDUCT.md
- Contributing Guidelines: https://github.com/k3d-io/k3d/blob/main/CONTRIBUTING.md
-->

# What

<!-- What does this PR do or change? -->
Bumps the base image of the k3d dind image.

Also refreshes the test matrix to currently supported Docker and k3s (Kubernetes) versions.

# Why

I mainly looked at this because we use the k3d dind image as a base image for our controller e2e-tests image. The installed software seemed outdated and I also noticed reported vulnerabilities.

Fixes https://github.com/k3d-io/k3d/issues/1482

<!-- Link issues, discussions, etc. or just explain why you're creating this PR -->

# Implications

Hopefully none - except improving the user experience when using the dind image.

<!--
Does this change existing behavior? If so, does it affect the CLI (cmd/) only or does it also/only change some internals of the Go module (pkg/)?
Especially mention breaking changes here!
-->

<!-- Get recognized using our all-contributors bot: https://github.com/k3d-io/k3d/blob/main/CONTRIBUTING.md#get-recognized -->
