### PR TITLE
docs: fixes typo for envvar

### DIFF
--- a/docs/usage/advanced/podman.md
+++ b/docs/usage/advanced/podman.md
@@ -137,7 +137,7 @@ podman machine ssh bash -e <<EOF
 EOF
 
 export DOCKER_HOST=ssh://core@localhost:53685
-export DOCKER_SOCKET=/run/user/501/podman/podman.sock
+export DOCKER_SOCK=/run/user/501/podman/podman.sock
 k3d cluster create --k3s-arg '--kubelet-arg=feature-gates=KubeletInUserNamespace=true@server:*'
 ```
 


### PR DESCRIPTION
<!-- 
Hi there, have an early THANK YOU for your contribution!
k3d is a community-driven project, so we really highly appreciate any support.
Please make sure, you've read our Code of Conduct and the Contributing Guidelines :)
- Code of Conduct: https://github.com/k3d-io/k3d/blob/main/CODE_OF_CONDUCT.md
- Contributing Guidelines: https://github.com/k3d-io/k3d/blob/main/CONTRIBUTING.md
-->

# What

<!-- What does this PR do or change? -->

Fixes typo in instructions for configuring k3d with podman on macos

# Why

<!-- Link issues, discussions, etc. or just explain why you're creating this PR -->

instructions are incorrect

# Implications

<!--
Does this change existing behavior? If so, does it affect the CLI (cmd/) only or does it also/only change some internals of the Go module (pkg/)?
Especially mention breaking changes here!
-->

not a breaking change

<!-- Get recognized using our all-contributors bot: https://github.com/k3d-io/k3d/blob/main/CONTRIBUTING.md#get-recognized -->
