### PR TITLE
fix: agent-node-files by append agentNode.HookActions

### DIFF
--- a/pkg/client/cluster.go
+++ b/pkg/client/cluster.go
@@ -986,7 +986,7 @@ func ClusterStart(ctx context.Context, runtime k3drt.Runtime, cluster *k3d.Clust
 			agentWG.Go(func() error {
 				return NodeStart(aCtx, runtime, currentAgentNode, &k3d.NodeStartOpts{
 					Wait:            true,
-					NodeHooks:       clusterStartOpts.NodeHooks,
+					NodeHooks:       append(clusterStartOpts.NodeHooks, agentNode.HookActions...),
 					EnvironmentInfo: clusterStartOpts.EnvironmentInfo,
 				})
 			})


### PR DESCRIPTION
 Fix #1527 

with tests:

```bash
#conf
  - description: 'registry.local-ca.pem'
    source: certs/registry/registry.local-ca.pem
    destination: /etc/ssl/certs/registry.local-ca.pem
    nodeFilters: 
    - "agent:0-1"
    - "server:*"

#traceLog
TRAC[0000] Filtered 1 nodes (filter: [server:*])        
TRAC[0000] Filtered 1 nodes (filter: [server:*])        
TRAC[0000] Filtered 3 nodes (filter: [agent:0-1 server:*])

#validate
root @ deb1013 in ~ |11:27:14  
$ docker exec -it k3d-mycluster-agent-1 sh
~ # find /etc/ssl/certs/
/etc/ssl/certs/
/etc/ssl/certs/ca-certificates.crt
/etc/ssl/certs/registry.local-ca.pem
```