### PR TITLE
feat(registry): add flag to enable storage deletion

### DIFF
--- a/cmd/registry/registryCreate.go
+++ b/cmd/registry/registryCreate.go
@@ -48,6 +48,7 @@ type regCreateFlags struct {
 	ProxyUsername  string
 	ProxyPassword  string
 	NoHelp         bool
+	DeleteEnabled  bool
 }
 
 var helptext string = `# You can now use the registry like this (example):
@@ -114,6 +115,7 @@ func NewCmdRegistryCreate() *cobra.Command {
 	cmd.Flags().StringVar(&flags.ProxyPassword, "proxy-password", "", "Specify the password of the proxied remote registry")
 
 	cmd.Flags().BoolVar(&flags.NoHelp, "no-help", false, "Disable the help text (How-To use the registry)")
+	cmd.Flags().BoolVar(&flags.DeleteEnabled, "delete-enabled", false, "Enable image deletion")
 
 	// done
 	return cmd
@@ -170,6 +172,8 @@ func parseCreateRegistryCmd(cmd *cobra.Command, args []string, flags *regCreateF
 			volumes = append(volumes, volume)
 		}
 	}
+
+	options.DeleteEnabled = flags.DeleteEnabled
 
 	return &k3d.Registry{Host: registryName, Image: flags.Image, ExposureOpts: *exposePort, Network: flags.Network, Options: options, Volumes: volumes}, clusters
 }

--- a/pkg/client/registry.go
+++ b/pkg/client/registry.go
@@ -88,6 +88,10 @@ func RegistryCreate(ctx context.Context, runtime runtimes.Runtime, reg *k3d.Regi
 		}
 	}
 
+	if reg.Options.DeleteEnabled {
+		registryNode.Env = append(registryNode.Env, "REGISTRY_STORAGE_DELETE_ENABLED=true")
+	}
+
 	if len(reg.Volumes) > 0 {
 		registryNode.Volumes = reg.Volumes
 	}
@@ -359,7 +363,7 @@ func RegistryGenerateLocalRegistryHostingConfigMapYAML(ctx context.Context, runt
 	return cmYaml, nil
 }
 
-// RegistryMergeConfig merges a source registry config into an existing dest registry cofnig
+// RegistryMergeConfig merges a source registry config into an existing dest registry config
 func RegistryMergeConfig(ctx context.Context, dest, src *wharfie.Registry) error {
 	if err := mergo.MergeWithOverwrite(dest, src); err != nil {
 		return fmt.Errorf("failed to merge registry configs: %w", err)

--- a/pkg/types/registry.go
+++ b/pkg/types/registry.go
@@ -33,8 +33,9 @@ const (
 )
 
 type RegistryOptions struct {
-	ConfigFile string        `json:"configFile,omitempty"`
-	Proxy      RegistryProxy `json:"proxy,omitempty"`
+	ConfigFile    string        `json:"configFile,omitempty"`
+	Proxy         RegistryProxy `json:"proxy,omitempty"`
+	DeleteEnabled bool          `json:"deleteEnabled,omitempty"`
 }
 
 type RegistryProxy struct {


### PR DESCRIPTION
<!-- 
Hi there, have an early THANK YOU for your contribution!
k3d is a community-driven project, so we really highly appreciate any support.
Please make sure, you've read our Code of Conduct and the Contributing Guidelines :)
- Code of Conduct: https://github.com/k3d-io/k3d/blob/main/CODE_OF_CONDUCT.md
- Contributing Guidelines: https://github.com/k3d-io/k3d/blob/main/CONTRIBUTING.md
-->

# What

<!-- What does this PR do or change? -->
This PR add the `--delete-enabled` flag to the `k3d registry create` command.

This will activate the storage deletion on the registry and thus allow removal of images.

Administrators will be able to manage the storage used by the registries in a more fine grained way since currently only re-creating the registry would free some space.

# Why

<!-- Link issues, discussions, etc. or just explain why you're creating this PR -->

Fixes #1541 

# Implications

<!--
Does this change existing behavior? If so, does it affect the CLI (cmd/) only or does it also/only change some internals of the Go module (pkg/)?
Especially mention breaking changes here!
-->

Nothing changes with regard to the defaults from the `k3d registry create`

<!-- Get recognized using our all-contributors bot: https://github.com/k3d-io/k3d/blob/main/CONTRIBUTING.md#get-recognized -->
