### PR TITLE
fixing the makefile; enforcing the registry port match;

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,6 @@ K3D_HELPER_VERSION ?=
 # Go options
 GO        ?= go
 GOENVPATH := $(shell go env GOPATH)
-PKG       := $(shell go work vendor)
 TAGS      :=
 TESTS     := ./...
 TESTFLAGS :=

--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ TESTS     := ./...
 TESTFLAGS :=
 LDFLAGS   := -w -s -X github.com/k3d-io/k3d/v5/version.Version=${GIT_TAG} -X github.com/k3d-io/k3d/v5/version.K3sVersion=${K3S_TAG}
 GCFLAGS   :=
-GOFLAGS   := -mod=readonly
+GOFLAGS   := -mod=vendor
 BINDIR    := $(CURDIR)/bin
 BINARIES  := k3d
 

--- a/cmd/cluster/clusterCreate.go
+++ b/cmd/cluster/clusterCreate.go
@@ -575,7 +575,7 @@ func applyCLIOverrides(cfg conf.SimpleConfig) (conf.SimpleConfig, error) {
 		}
 		cfg.Registries.Create.Name = fvSplit[0]
 		if len(fvSplit) > 1 {
-			exposeAPI, err = cliutil.ParsePortExposureSpec(fvSplit[1], "1234") // internal port is unused after all
+			exposeAPI, err = cliutil.ParseRegistryPortExposureSpec(fvSplit[1])
 			if err != nil {
 				return cfg, fmt.Errorf("failed to registry port spec: %w", err)
 			}

--- a/cmd/registry/registryCreate.go
+++ b/cmd/registry/registryCreate.go
@@ -134,7 +134,7 @@ func parseCreateRegistryCmd(cmd *cobra.Command, args []string, flags *regCreateF
 	}
 
 	// --port
-	exposePort, err := cliutil.ParsePortExposureSpec(ppFlags.Port, k3d.DefaultRegistryPort)
+	exposePort, err := cliutil.ParseRegistryPortExposureSpec(ppFlags.Port)
 	if err != nil {
 		l.Log().Errorln("Failed to parse registry port")
 		l.Log().Fatalln(err)

--- a/cmd/util/ports.go
+++ b/cmd/util/ports.go
@@ -36,8 +36,16 @@ import (
 
 var apiPortRegexp = regexp.MustCompile(`^(?P<hostref>(?P<hostip>\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})|(?P<hostname>\S+):)?(?P<port>(\d{1,5}|random))$`)
 
-// ParsePortExposureSpec parses/validates a string to create an exposePort struct from it
 func ParsePortExposureSpec(exposedPortSpec, internalPort string) (*k3d.ExposureOpts, error) {
+	return parsePortExposureSpec(exposedPortSpec, internalPort, false)
+}
+
+func ParseRegistryPortExposureSpec(exposedPortSpec string) (*k3d.ExposureOpts, error) {
+	return parsePortExposureSpec(exposedPortSpec, k3d.DefaultRegistryPort, true)
+}
+
+// ParsePortExposureSpec parses/validates a string to create an exposePort struct from it
+func parsePortExposureSpec(exposedPortSpec, internalPort string, enforcePortMatch bool) (*k3d.ExposureOpts, error) {
 	match := apiPortRegexp.FindStringSubmatch(exposedPortSpec)
 
 	if len(match) == 0 {
@@ -83,7 +91,7 @@ func ParsePortExposureSpec(exposedPortSpec, internalPort string) (*k3d.ExposureO
 	}
 
 	// port: get a free one if there's none defined or set to random
-	if submatches["port"] == "" || submatches["port"] == "random" {
+	if submatches["port"] == "random" {
 		l.Log().Debugf("Port Exposure Mapping didn't specify hostPort, choosing one randomly...")
 		freePort, err := GetFreePort()
 		if err != nil || freePort == 0 {
@@ -94,6 +102,10 @@ func ParsePortExposureSpec(exposedPortSpec, internalPort string) (*k3d.ExposureO
 			submatches["port"] = strconv.Itoa(freePort)
 			l.Log().Debugf("Got free port for Port Exposure: '%d'", freePort)
 		}
+	}
+
+	if enforcePortMatch {
+		internalPort = submatches["port"]
 	}
 
 	realPortString += fmt.Sprintf("%s:%s/tcp", submatches["port"], internalPort)

--- a/cmd/util/ports_test.go
+++ b/cmd/util/ports_test.go
@@ -1,0 +1,41 @@
+package util
+
+import (
+	"strings"
+	"testing"
+
+	"gotest.tools/assert"
+)
+
+func Test_ParsePortExposureSpec_PortMatchEnforcement(t *testing.T) {
+
+	r, err := ParsePortExposureSpec("9999", "1111")
+	if nil != err {
+		t.Fail()
+	} else {
+		assert.Equal(t, string(r.Port), "1111/tcp")
+		assert.Equal(t, string(r.Binding.HostPort), "9999")
+	}
+
+	r, err = ParseRegistryPortExposureSpec("9999")
+	if nil != err {
+		t.Fail()
+	} else {
+		assert.Equal(t, string(r.Port), "9999/tcp")
+		assert.Equal(t, string(r.Binding.HostPort), "9999")
+	}
+
+	r, err = ParsePortExposureSpec("random", "1")
+	if nil != err {
+		t.Fail()
+	} else {
+		assert.Assert(t, strings.Split(string(r.Port), "/")[0] != string(r.Binding.HostPort))
+	}
+
+	r, err = ParseRegistryPortExposureSpec("random")
+	if nil != err {
+		t.Fail()
+	} else {
+		assert.Equal(t, strings.Split(string(r.Port), "/")[0], string(r.Binding.HostPort))
+	}
+}

--- a/pkg/client/registry.go
+++ b/pkg/client/registry.go
@@ -76,6 +76,10 @@ func RegistryCreate(ctx context.Context, runtime runtimes.Runtime, reg *k3d.Regi
 		Env:      []string{},
 	}
 
+	if reg.ExposureOpts.Binding.HostPort != "" {
+		registryNode.Env = append(registryNode.Env, fmt.Sprintf("REGISTRY_HTTP_ADDR=:%s", reg.ExposureOpts.Binding.HostPort))
+	}
+
 	if reg.Options.Proxy.RemoteURL != "" {
 		registryNode.Env = append(registryNode.Env, fmt.Sprintf("REGISTRY_PROXY_REMOTEURL=%s", reg.Options.Proxy.RemoteURL))
 

--- a/pkg/config/transform.go
+++ b/pkg/config/transform.go
@@ -320,7 +320,7 @@ func TransformSimpleToClusterConfig(ctx context.Context, runtime runtimes.Runtim
 			epSpecHost = simpleConfig.Registries.Create.Host
 		}
 
-		regPort, err := cliutil.ParsePortExposureSpec(fmt.Sprintf("%s:%s", epSpecHost, epSpecPort), k3d.DefaultRegistryPort)
+		regPort, err := cliutil.ParseRegistryPortExposureSpec(fmt.Sprintf("%s:%s", epSpecHost, epSpecPort))
 		if err != nil {
 			return nil, fmt.Errorf("failed to get port for registry: %w", err)
 		}

--- a/tests/test_registry.sh
+++ b/tests/test_registry.sh
@@ -52,7 +52,7 @@ kubectl get configmap -n kube-public local-registry-hosting -o go-template='{{in
 
 # 3. load an image into the registry
 info "Pushing an image to the registry..."
-registryPort=$(docker inspect $registryname | jq '.[0].NetworkSettings.Ports["5000/tcp"][0].HostPort' | sed -E 's/"//g')
+registryPort=$(docker inspect $registryname | jq '.[0].NetworkSettings.Ports | with_entries(select(.value | . != null)) | to_entries[0].value[0].HostPort' | sed -E 's/"//g')
 docker pull alpine:latest > /dev/null
 docker tag alpine:latest "localhost:$registryPort/alpine:local" > /dev/null
 docker push "localhost:$registryPort/alpine:local" || failed "Failed to push image to managed registry"


### PR DESCRIPTION
makefile changes make sure that the _vendor_ directory is used by the build process (the `GOFLAGS` change) as well as that the local cache isn't needlessly built (both changes) - since there is the said directory.

the code changes fix [issue 1406](https://github.com/k3d-io/k3d/issues/1406), making sure that the internal and external listening ports of the registries match if they are set to a non-default value (and that the Docker port mapping of the registry container is set up correctly as well).

---

when i run the E2E tests locally, 8 of them are failing for a seemingly unrelated reason.   i'd like to be able to see the CI test execution output.
