### PR TITLE
Exclude s390x as arch-specific tag from version list

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -384,7 +384,7 @@ func NewCmdVersionLs() *cobra.Command {
 	}
 
 	cmd.Flags().StringVarP(&flags.includeRegexp, "include", "i", ".*", "Include Regexp (default includes everything")
-	cmd.Flags().StringVarP(&flags.excludeRegexp, "exclude", "e", ".+(rc|engine|alpha|beta|dev|test|arm|arm64|amd64).*", "Exclude Regexp (default excludes pre-releases and arch-specific tags)")
+	cmd.Flags().StringVarP(&flags.excludeRegexp, "exclude", "e", ".+(rc|engine|alpha|beta|dev|test|arm|arm64|amd64|s390x).*", "Exclude Regexp (default excludes pre-releases and arch-specific tags)")
 	cmd.Flags().StringVarP(&flags.format, "format", "f", string(VersionLsOutputFormatRaw), "[DEPRECATED] Use --output instead")
 	cmd.Flags().StringVarP(&flags.outputFormat, "output", "o", string(VersionLsOutputFormatRaw), "Output Format [raw | repo]")
 	cmd.MarkFlagsMutuallyExclusive("format", "output")

--- a/docs/usage/commands/k3d_version_list.md
+++ b/docs/usage/commands/k3d_version_list.md
@@ -9,7 +9,7 @@ k3d version list COMPONENT [flags]
 ### Options
 
 ```
-  -e, --exclude string   Exclude Regexp (default excludes pre-releases and arch-specific tags) (default ".+(rc|engine|alpha|beta|dev|test|arm|arm64|amd64).*")
+  -e, --exclude string   Exclude Regexp (default excludes pre-releases and arch-specific tags) (default ".+(rc|engine|alpha|beta|dev|test|arm|arm64|amd64|s390x).*")
   -f, --format string    [DEPRECATED] Use --output instead (default "raw")
   -h, --help             help for list
   -i, --include string   Include Regexp (default includes everything (default ".*")


### PR DESCRIPTION
<!-- 
Hi there, have an early THANK YOU for your contribution!
k3d is a community-driven project, so we really highly appreciate any support.
Please make sure, you've read our Code of Conduct and the Contributing Guidelines :)
- Code of Conduct: https://github.com/k3d-io/k3d/blob/main/CODE_OF_CONDUCT.md
- Contributing Guidelines: https://github.com/k3d-io/k3d/blob/main/CONTRIBUTING.md
-->

# What

Documentation says that `default excludes pre-releases and arch-specific tags` is default.
s390x is arch specific, it should be excluded by default.

Current behaviour:
```bash
~ k3d version list k3s -i '1.28.4'
v1.28.4-k3s2
v1.28.4-k3s1-s390x
v1.28.4-k3s1
```

<!-- Get recognized using our all-contributors bot: https://github.com/k3d-io/k3d/blob/main/CONTRIBUTING.md#get-recognized -->
