### PR TITLE
Fix docker registry auth example

### DIFF
--- a/docs/faq/faq.md
+++ b/docs/faq/faq.md
@@ -148,7 +148,7 @@ c) authenticate containerd inside k3s/k3d to use your DockerHub user
   ```yaml
   # saved as e.g. $HOME/registries.yaml
   configs:
-    "docker.io":
+    "registry-1.docker.io":
       auth:
         username: "$USERNAME"
         password: "$PASSWORD"


### PR DESCRIPTION
<!-- 
Hi there, have an early THANK YOU for your contribution!
k3d is a community-driven project, so we really highly appreciate any support.
Please make sure, you've read our Code of Conduct and the Contributing Guidelines :)
- Code of Conduct: https://github.com/k3d-io/k3d/blob/main/CODE_OF_CONDUCT.md
- Contributing Guidelines: https://github.com/k3d-io/k3d/blob/main/CONTRIBUTING.md
-->

# What

FAQ example to authenticate docker registry is wrong.
In pod error there is `registry-1.docker.io`, if I use this to authenticate it works fine.

```
Failed to pull image "busybox": failed to pull and unpack image "docker.io/library/busybox:latest":
  failed to copy: httpReadSeeker: failed open: unexpected status code 
https://registry-1.docker.io/v2/library/busybox/manifests/sha256:a5d0ce49aa801d475da48f8cb163c354ab95cab073cd3c138bd458fc8257fbf1:
  429 Too Many Requests
```

To test this I created two k3d clusters, one with `docker.io`, another with `registry-1.docker.io`.
When docker.io started to hit rate limits, registry-1.docker.io was still working fine.

Test command: `kubectl run pod --image=busybox --command --restart=Never -it --rm -- true`

