### PR TITLE
fix: files option for config on windows

### DIFF
--- a/pkg/util/files.go
+++ b/pkg/util/files.go
@@ -95,7 +95,7 @@ func ReadFileSource(configFile, source string) ([]byte, error) {
 // ResolveFileDestination determines the file destination and resolves it if it has a magic shortcut.
 func ResolveFileDestination(destPath string) (string, error) {
 	// If the destination path is absolute, then use it as it is.
-	if filepath.IsAbs(destPath) {
+	if path.IsAbs(destPath) {
 		l.Log().Debugf("resolved destination with absolute path '%s'", destPath)
 		return destPath, nil
 	}
@@ -104,9 +104,9 @@ func ResolveFileDestination(destPath string) (string, error) {
 	destPathTree := strings.Split(destPath, string(os.PathSeparator))
 	if shortcutPath, found := k3s.K3sPathShortcuts[destPathTree[0]]; found {
 		destPathTree[0] = shortcutPath
-		destPathResolved := filepath.Join(destPathTree...)
+		destPathResolved := path.Join(destPathTree...)
 		l.Log().Debugf("resolved destination with magic shortcut path: '%s'", destPathResolved)
-		return filepath.Join(destPathResolved), nil
+		return path.Join(destPathResolved), nil
 	}
 
 	return "", fmt.Errorf("destination can be only absolute path or starts with predefined shortcut path. Could not resolve destination file path: %s", destPath)


### PR DESCRIPTION
<!-- 
Hi there, have an early THANK YOU for your contribution!
k3d is a community-driven project, so we really highly appreciate any support.
Please make sure, you've read our Code of Conduct and the Contributing Guidelines :)
- Code of Conduct: https://github.com/k3d-io/k3d/blob/main/CODE_OF_CONDUCT.md
- Contributing Guidelines: https://github.com/k3d-io/k3d/blob/main/CONTRIBUTING.md
-->

# What

This PR fixes a bug that prevents `files` option in config file from working on windows.

# Why

Currently when parsing the config file with `files` option the destination attribute is resolved using the `filepath` package which handles paths based on operating system. This is incorrect for the `destination` attribute as its a path used inside the container and therefore should always be unix style. 

For reference the following config results in the following file inside the server container:

```yaml
apiVersion: k3d.io/v1alpha5
kind: Simple
metadata:
  name: test-cluster
servers: 1
agents: 2
kubeAPI:
  host: localhost
image: rancher/k3s:v1.32.3-k3s1
subnet: "172.28.0.0/16"
ports:
  - port: 8080:80
    nodeFilters:
      - loadbalancer
files:
- description: LoadBalancer configuration
  source: .\cluster-configs\loadbalancer.yaml
  destination: \var\lib\rancher\k3s\server\manifests\traefik-config.yaml
  nodeFilters:
  - server:*
```

```bash
$ docker exec -it 90 /bin/sh
~ # ls
'\var\lib\rancher\k3s\server\manifests\traefik-config.yaml'   dev   k3d   output   run    sys   usr
 bin                                                          etc   lib   proc     sbin   tmp   var
```

If the config is updated to use unix paths (e.g. `/`) parsing fails due to use of `filepath.IsAbs` function that expects windows style path.

```
$ k3d cluster create --config .\k3dcluster.yaml
INFO[0000] Using config file .\k3dcluster.yaml (k3d.io/v1alpha5#simple)
INFO[0000] portmapping '8080:80' targets the loadbalancer: defaulting to [servers:*:proxy agents:*:proxy]
WARN[0000] No node filter specified
FATA[0000] destination path is not correct: destination can be only absolute path or starts with predefined shortcut path. Could not resolve destination file path: /var/lib/rancher/k3s/server/manifests/traefik-config.yaml
```

# Implications

This fix changes no existing behavior besides getting the files option field to work on windows machines
