### PR TITLE
Skip DNS fix on Colima

### DIFF
--- a/pkg/types/fixes/fixes.go
+++ b/pkg/types/fixes/fixes.go
@@ -102,7 +102,18 @@ var fixNeeded = map[K3DFixEnv]func(runtime runtimes.Runtime) bool{
 		l.Log().Debugf("[autofix cgroupsv2] cgroupVersion: %d", cgroupVersion)
 		return cgroupVersion == 2
 	},
-	EnvFixDNS: func(_ runtimes.Runtime) bool {
+	EnvFixDNS: func(runtime runtimes.Runtime) bool {
+		runtimeInfo, err := runtime.Info()
+		if err != nil {
+			l.Log().Warnf("Failed to get runtime information: %+v", err)
+			return false
+		}
+
+		if runtimeInfo.InfoName == "colima" {
+			l.Log().Debug("Skipping the DNS fix on Colima.")
+			return false
+		}
+
 		return true
 	},
 	EnvFixMounts: func(_ runtimes.Runtime) bool {


### PR DESCRIPTION
# What

This PR fixes the behavior reported in the issue #1449 by disabling the DNS fix when running on the [Colima runtime](https://github.com/abiosoft/colima).

# Why

Without this PR, whenever a new cluster is built, Docker images are not downloaded because the DNS is not reachable. This can be fixed by using the `K3D_FIX_DNS=0` but it would be better if it would work out of the box.

# Implications

This PR doesn't change anything for those who already use the fix mentioned above. It only helps new users to make their cluster running without having to look for a solution for the broken DNS.