### PR TITLE
Update Dockerfile for nvidia runtime

### DIFF
--- a/docs/usage/advanced/cuda/Dockerfile
+++ b/docs/usage/advanced/cuda/Dockerfile
@@ -12,6 +12,9 @@ RUN apt-get update && apt-get install -y curl \
       tee /etc/apt/sources.list.d/nvidia-container-toolkit.list \
     && apt-get update && apt-get install -y nvidia-container-toolkit \
     && nvidia-ctk runtime configure --runtime=containerd
+    # Set alternative 'nvidia' runtime as default prior to container start. 
+    # GPU nodes will always use the nvidia runtime without the need to explicitly define it.
+    && mkdir -p /etc/rancher/k3s && echo "default-runtime: nvidia" > /etc/rancher/k3s/config.yaml
 
 COPY --from=k3s / / --exclude=/bin
 COPY --from=k3s /bin /bin


### PR DESCRIPTION
Setting the runtime to default to nvidia as these are GPU nodes and will likely run GPU-accelerated workloads only. I'm happy to have this as optional to avoid confusion but I think it's beneficial for users to decide for themselves how to manage the configuration.

<!-- 
Hi there, have an early THANK YOU for your contribution!
k3d is a community-driven project, so we really highly appreciate any support.
Please make sure, you've read our Code of Conduct and the Contributing Guidelines :)
- Code of Conduct: https://github.com/k3d-io/k3d/blob/main/CODE_OF_CONDUCT.md
- Contributing Guidelines: https://github.com/k3d-io/k3d/blob/main/CONTRIBUTING.md
-->

# What

Creates a K3s configuration file setting the default runtime to nvidia. This configuration is passed at cluster bringup when k3s agent is run. 

# Why

I don't see any issue for GPU specific nodes and it avoids the overhead of defining the runtime in every YAML definition. 

# Implications

<!--
Does this change existing behavior? If so, does it affect the CLI (cmd/) only or does it also/only change some internals of the Go module (pkg/)?
Especially mention breaking changes here!
--> N/A

<!-- Get recognized using our all-contributors bot: https://github.com/k3d-io/k3d/blob/main/CONTRIBUTING.md#get-recognized -->
