### PR TITLE
Update the hardcoded k3s version from 1.21 to 1.32

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -38,7 +38,7 @@ var Version string
 var HelperVersionOverride string
 
 // K3sVersion should contain the latest version tag of k3s (hardcoded at build time)
-var K3sVersion = "v1.32.5+k3s1"
+var K3sVersion = "v1.32.5-k3s1"
 
 type httpClient struct {
 	client  *http.Client

--- a/version/version.go
+++ b/version/version.go
@@ -38,7 +38,7 @@ var Version string
 var HelperVersionOverride string
 
 // K3sVersion should contain the latest version tag of k3s (hardcoded at build time)
-var K3sVersion = "v1.21.7-k3s1"
+var K3sVersion = "v1.33.1+k3s1"
 
 type httpClient struct {
 	client  *http.Client

--- a/version/version.go
+++ b/version/version.go
@@ -38,7 +38,7 @@ var Version string
 var HelperVersionOverride string
 
 // K3sVersion should contain the latest version tag of k3s (hardcoded at build time)
-var K3sVersion = "v1.33.1+k3s1"
+var K3sVersion = "v1.32.5+k3s1"
 
 type httpClient struct {
 	client  *http.Client


### PR DESCRIPTION
# What

Update the hardcoded k3s version from 1.21 to 1.32

# Why

This is overridden at build time in the Makefile but some distros might not use that and fall back to the default version.
This is the case for example for Nix where the user _can_ override the version but if that doesn't happen they default to a very old one (from 2021 or so).

https://github.com/NixOS/nixpkgs/blob/0d36547deb33d32f05add583384ae5858dadb464/pkgs/by-name/k3/k3d/package.nix#L6

This just updates the default version to the current stable k3s version.

# Implications

It changes the default version of k3s for users which build k3d themselves without using the Makefile or with custom changes to it.