### PR TITLE
chore(renovate): Add custom manager for k3s version tracking

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -26,6 +26,13 @@
       ]
     },
     {
+      "matchPackageNames": [
+        "k3s"
+      ],
+      "enabled": true,
+      "branchName": "renovate/k3s-{{newVersion}}"
+    },
+    {
       "automerge": true,
       "automergeType": "pr",
       "automergeStrategy": "squash",
@@ -33,5 +40,25 @@
         "*"
       ]
     }
-  ]
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^version\\/version.go$/"],
+      "matchStrings": [
+        "var K3sVersion = \"(?<currentValue>v[0-9a-zA-Z\\.-]+-k3s[0-9]*)\""
+      ],
+      "depNameTemplate": "k3s",
+      "versioningTemplate": "loose",
+      "datasourceTemplate": "custom.k3s"
+    }
+  ],
+  "customDatasources": {
+    "k3s": {
+      "defaultRegistryUrlTemplate": "https://update.k3s.io/v1-release/channels",
+      "transformTemplates": [
+        "{\"releases\":[{\"version\": $replace($$.(data[id = 'stable'].latest), '+', '-'),\"sourceUrl\":\"https://github.com/k3s-io/k3s\",\"changelogUrl\":$join([\"https://github.com/k3s-io/k3s/releases/tag/\",data[id = 'stable'].latest])}],\"sourceUrl\": \"https://github.com/k3s-io/k3s\",\"homepage\": \"https://k3s.io/\"}"
+      ]
+    }
+  }
 }


### PR DESCRIPTION
# What

Adds configuration to renovate.json to automatically track and update the k3s version managed internally by the k3d project.     

# Why
This PR was inspired by the discussions in [k3d Issue #1560](https://github.com/k3d-io/k3d/issues/1560).  
This achieves the following objectives:

## Automated k3s Version Tracking
Instead of manually updating the k3s version referenced by k3d, Renovate will read the current version from `version.go`, compare it with the latest version from the official channel, and automatically create update PRs.  

## Reduce Manual Update Burden
Frees developers from continuously monitoring new k3s releases and manually updating the version. This eliminates the need for manual version update PRs like [k3d PR \#1589](https://github.com/k3d-io/k3d/pull/1589).  

# Implications

- This PR does not introduce any breaking changes to the existing codebase.
- The Renovate bot will monitor the k3s version in the version/version.go file, and when a new k3s release is detected, it will automatically create an update PR with a branch name of renovate/k3s-{{newVersion}}.   
-  Related PRs are created periodically, depending on how often k3 is updated.

# References

The following pull requests can be referred to as examples of PRs that will be created by Renovate in the future:

- [k3d PR \#25 (kobayashiyabako16g/k3d)](https://github.com/kobayashiyabako16g/k3d/pull/25)

This renovate.json configuration is based on the k3s custom data source example in the official Renovate documentation.

- [Renovate Custom Data Sources \- k3s Example](https://docs.renovatebot.com/modules/datasource/custom/#k3s)

