### PR TITLE
Build process change

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,6 @@ K3D_HELPER_VERSION ?=
 # Go options
 GO        ?= go
 GOENVPATH := $(shell go env GOPATH)
-PKG       := $(shell go work vendor)
 TAGS      :=
 TESTS     := ./...
 TESTFLAGS :=

--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ TESTS     := ./...
 TESTFLAGS :=
 LDFLAGS   := -w -s -X github.com/k3d-io/k3d/v5/version.Version=${GIT_TAG} -X github.com/k3d-io/k3d/v5/version.K3sVersion=${K3S_TAG}
 GCFLAGS   :=
-GOFLAGS   := -mod=readonly
+GOFLAGS   := -mod=vendor
 BINDIR    := $(CURDIR)/bin
 BINARIES  := k3d
 


### PR DESCRIPTION
as discussed, i'm re-applying build process changes from [1550](https://github.com/k3d-io/k3d/pull/1550).

they make sure that the _vendor_ directory is used by the build process (the `GOFLAGS` change) as well as that the Go system cache isn't needlessly built (both changes) - since the _vendor_ directory exists and should be used.