### PR TITLE
feat(1406): introducing the option to match registry ports;

### DIFF
--- a/cmd/registry/registryCreate.go
+++ b/cmd/registry/registryCreate.go
@@ -42,13 +42,14 @@ type regCreatePreProcessedFlags struct {
 }
 
 type regCreateFlags struct {
-	Image          string
-	Network        string
-	ProxyRemoteURL string
-	ProxyUsername  string
-	ProxyPassword  string
-	NoHelp         bool
-	DeleteEnabled  bool
+	Image            string
+	Network          string
+	ProxyRemoteURL   string
+	ProxyUsername    string
+	ProxyPassword    string
+	NoHelp           bool
+	DeleteEnabled    bool
+	EnforcePortMatch bool
 }
 
 var helptext string = `# You can now use the registry like this (example):
@@ -116,6 +117,7 @@ func NewCmdRegistryCreate() *cobra.Command {
 
 	cmd.Flags().BoolVar(&flags.NoHelp, "no-help", false, "Disable the help text (How-To use the registry)")
 	cmd.Flags().BoolVar(&flags.DeleteEnabled, "delete-enabled", false, "Enable image deletion")
+	cmd.Flags().BoolVar(&flags.EnforcePortMatch, "enforce-port-match", false, "Make the internal registry port match the external one")
 
 	// done
 	return cmd
@@ -134,7 +136,7 @@ func parseCreateRegistryCmd(cmd *cobra.Command, args []string, flags *regCreateF
 	}
 
 	// --port
-	exposePort, err := cliutil.ParsePortExposureSpec(ppFlags.Port, k3d.DefaultRegistryPort)
+	exposePort, err := cliutil.ParsePortExposureSpec(ppFlags.Port, k3d.DefaultRegistryPort, flags.EnforcePortMatch)
 	if err != nil {
 		l.Log().Errorln("Failed to parse registry port")
 		l.Log().Fatalln(err)
@@ -174,6 +176,7 @@ func parseCreateRegistryCmd(cmd *cobra.Command, args []string, flags *regCreateF
 	}
 
 	options.DeleteEnabled = flags.DeleteEnabled
+	options.EnforcePortMatch = flags.EnforcePortMatch
 
 	return &k3d.Registry{Host: registryName, Image: flags.Image, ExposureOpts: *exposePort, Network: flags.Network, Options: options, Volumes: volumes}, clusters
 }

--- a/cmd/util/ports.go
+++ b/cmd/util/ports.go
@@ -37,7 +37,7 @@ import (
 var apiPortRegexp = regexp.MustCompile(`^(?P<hostref>(?P<hostip>\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})|(?P<hostname>\S+):)?(?P<port>(\d{1,5}|random))$`)
 
 // ParsePortExposureSpec parses/validates a string to create an exposePort struct from it
-func ParsePortExposureSpec(exposedPortSpec, internalPort string) (*k3d.ExposureOpts, error) {
+func ParsePortExposureSpec(exposedPortSpec, internalPort string, enforcePortMatch bool) (*k3d.ExposureOpts, error) {
 	match := apiPortRegexp.FindStringSubmatch(exposedPortSpec)
 
 	if len(match) == 0 {
@@ -83,7 +83,7 @@ func ParsePortExposureSpec(exposedPortSpec, internalPort string) (*k3d.ExposureO
 	}
 
 	// port: get a free one if there's none defined or set to random
-	if submatches["port"] == "" || submatches["port"] == "random" {
+	if submatches["port"] == "random" {
 		l.Log().Debugf("Port Exposure Mapping didn't specify hostPort, choosing one randomly...")
 		freePort, err := GetFreePort()
 		if err != nil || freePort == 0 {
@@ -95,6 +95,10 @@ func ParsePortExposureSpec(exposedPortSpec, internalPort string) (*k3d.ExposureO
 			l.Log().Debugf("Got free port for Port Exposure: '%d'", freePort)
 		}
 	}
+
+    if enforcePortMatch {
+		internalPort = submatches["port"]
+    }
 
 	realPortString += fmt.Sprintf("%s:%s/tcp", submatches["port"], internalPort)
 

--- a/cmd/util/ports.go
+++ b/cmd/util/ports.go
@@ -96,9 +96,9 @@ func ParsePortExposureSpec(exposedPortSpec, internalPort string, enforcePortMatc
 		}
 	}
 
-    if enforcePortMatch {
+	if enforcePortMatch {
 		internalPort = submatches["port"]
-    }
+	}
 
 	realPortString += fmt.Sprintf("%s:%s/tcp", submatches["port"], internalPort)
 

--- a/cmd/util/ports_test.go
+++ b/cmd/util/ports_test.go
@@ -4,38 +4,26 @@ import (
 	"strings"
 	"testing"
 
-	"gotest.tools/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_ParsePortExposureSpec_PortMatchEnforcement(t *testing.T) {
 
 	r, err := ParsePortExposureSpec("9999", "1111", false)
-	if nil != err {
-		t.Fail()
-	} else {
-		assert.Equal(t, string(r.Port), "1111/tcp")
-		assert.Equal(t, string(r.Binding.HostPort), "9999")
-	}
+	require.Nil(t, err)
+	require.Equal(t, string(r.Port), "1111/tcp")
+	require.Equal(t, string(r.Binding.HostPort), "9999")
 
 	r, err = ParsePortExposureSpec("9999", "1111", true)
-	if nil != err {
-		t.Fail()
-	} else {
-		assert.Equal(t, string(r.Port), "9999/tcp")
-		assert.Equal(t, string(r.Binding.HostPort), "9999")
-	}
+	require.Nil(t, err)
+	require.Equal(t, string(r.Port), "9999/tcp")
+	require.Equal(t, string(r.Binding.HostPort), "9999")
 
 	r, err = ParsePortExposureSpec("random", "1", false)
-	if nil != err {
-		t.Fail()
-	} else {
-		assert.Assert(t, strings.Split(string(r.Port), "/")[0] != string(r.Binding.HostPort))
-	}
+	require.Nil(t, err)
+	require.NotEqual(t, strings.Split(string(r.Port), "/")[0], string(r.Binding.HostPort))
 
 	r, err = ParsePortExposureSpec("random", "", true)
-	if nil != err {
-		t.Fail()
-	} else {
-		assert.Equal(t, strings.Split(string(r.Port), "/")[0], string(r.Binding.HostPort))
-	}
+	require.Nil(t, err)
+	require.Equal(t, strings.Split(string(r.Port), "/")[0], string(r.Binding.HostPort))
 }

--- a/cmd/util/ports_test.go
+++ b/cmd/util/ports_test.go
@@ -1,0 +1,41 @@
+package util
+
+import (
+	"strings"
+	"testing"
+
+	"gotest.tools/assert"
+)
+
+func Test_ParsePortExposureSpec_PortMatchEnforcement(t *testing.T) {
+
+	r, err := ParsePortExposureSpec("9999", "1111", false)
+	if nil != err {
+		t.Fail()
+	} else {
+		assert.Equal(t, string(r.Port), "1111/tcp")
+		assert.Equal(t, string(r.Binding.HostPort), "9999")
+	}
+
+	r, err = ParsePortExposureSpec("9999", "1111", true)
+	if nil != err {
+		t.Fail()
+	} else {
+		assert.Equal(t, string(r.Port), "9999/tcp")
+		assert.Equal(t, string(r.Binding.HostPort), "9999")
+	}
+
+	r, err = ParsePortExposureSpec("random", "1", false)
+	if nil != err {
+		t.Fail()
+	} else {
+		assert.Assert(t, strings.Split(string(r.Port), "/")[0] != string(r.Binding.HostPort))
+	}
+
+	r, err = ParsePortExposureSpec("random", "", true)
+	if nil != err {
+		t.Fail()
+	} else {
+		assert.Equal(t, strings.Split(string(r.Port), "/")[0], string(r.Binding.HostPort))
+	}
+}

--- a/pkg/client/registry.go
+++ b/pkg/client/registry.go
@@ -76,6 +76,10 @@ func RegistryCreate(ctx context.Context, runtime runtimes.Runtime, reg *k3d.Regi
 		Env:      []string{},
 	}
 
+	if reg.Options.EnforcePortMatch {
+		registryNode.Env = append(registryNode.Env, fmt.Sprintf("REGISTRY_HTTP_ADDR=:%s", reg.ExposureOpts.Binding.HostPort))
+	}
+
 	if reg.Options.Proxy.RemoteURL != "" {
 		registryNode.Env = append(registryNode.Env, fmt.Sprintf("REGISTRY_PROXY_REMOTEURL=%s", reg.Options.Proxy.RemoteURL))
 

--- a/pkg/config/transform.go
+++ b/pkg/config/transform.go
@@ -320,7 +320,7 @@ func TransformSimpleToClusterConfig(ctx context.Context, runtime runtimes.Runtim
 			epSpecHost = simpleConfig.Registries.Create.Host
 		}
 
-		regPort, err := cliutil.ParsePortExposureSpec(fmt.Sprintf("%s:%s", epSpecHost, epSpecPort), k3d.DefaultRegistryPort)
+		regPort, err := cliutil.ParsePortExposureSpec(fmt.Sprintf("%s:%s", epSpecHost, epSpecPort), k3d.DefaultRegistryPort, simpleConfig.Registries.Create.EnforcePortMatch)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get port for registry: %w", err)
 		}
@@ -342,7 +342,8 @@ func TransformSimpleToClusterConfig(ctx context.Context, runtime runtimes.Runtim
 			ExposureOpts: *regPort,
 			Volumes:      simpleConfig.Registries.Create.Volumes,
 			Options: k3d.RegistryOptions{
-				Proxy: simpleConfig.Registries.Create.Proxy,
+				Proxy:            simpleConfig.Registries.Create.Proxy,
+				EnforcePortMatch: simpleConfig.Registries.Create.EnforcePortMatch,
 			},
 		}
 	}

--- a/pkg/config/v1alpha5/schema.json
+++ b/pkg/config/v1alpha5/schema.json
@@ -368,6 +368,10 @@
               "examples": [
                 "/tmp/registry:/var/lib/registry"
               ]
+            },
+            "enforcePortMatch": {
+              "type": "boolean",
+              "default": false
             }
           },
           "additionalProperties": false

--- a/pkg/config/v1alpha5/types.go
+++ b/pkg/config/v1alpha5/types.go
@@ -97,6 +97,7 @@ type SimpleConfigRegistryCreateConfig struct {
 	Image    string            `mapstructure:"image" json:"image,omitempty"`
 	Proxy    k3d.RegistryProxy `mapstructure:"proxy" json:"proxy,omitempty"`
 	Volumes  []string          `mapstructure:"volumes" json:"volumes,omitempty"`
+	EnforcePortMatch bool      `mapstructure:"enforcePortMatch" json:"enforcePortMatch,omitempty"`
 }
 
 // SimpleConfigOptionsKubeconfig describes the set of options referring to the kubeconfig during cluster creation.

--- a/pkg/types/registry.go
+++ b/pkg/types/registry.go
@@ -33,9 +33,10 @@ const (
 )
 
 type RegistryOptions struct {
-	ConfigFile    string        `json:"configFile,omitempty"`
-	Proxy         RegistryProxy `json:"proxy,omitempty"`
-	DeleteEnabled bool          `json:"deleteEnabled,omitempty"`
+	ConfigFile       string        `json:"configFile,omitempty"`
+	Proxy            RegistryProxy `json:"proxy,omitempty"`
+	DeleteEnabled    bool          `json:"deleteEnabled,omitempty"`
+	EnforcePortMatch bool          `json:"enforcePortMatch,omitempty"`
 }
 
 type RegistryProxy struct {


### PR DESCRIPTION
i'm addressing [issue 1406](https://github.com/k3d-io/k3d/issues/1406) again, but this time it's a flag to be explicitly provided, in order not to affect the existing usage.

i've altered CLI registry creation as well as cluster CLI- and config-based creation.

the `REGISTRY_HTTP_ADDR` environment variable handles the default registry image as well as the [k3d-registry-dockerd](https://github.com/ligfx/k3d-registry-dockerd) image.

as discussed - i want to see the E2E tests pass.