### PR TITLE
feat(https://github.com/k3d-io/k3d/issues/1570): introducing the --port-delete flag;

### DIFF
--- a/cmd/cluster/clusterEdit.go
+++ b/cmd/cluster/clusterEdit.go
@@ -57,8 +57,8 @@ func NewCmdClusterEdit() *cobra.Command {
 	// add subcommands
 
 	// add flags
-	cmd.Flags().StringArray("port-add", nil, "Map ports from the node containers (via the serverlb) to the host (Format: `[HOST:][HOSTPORT:]CONTAINERPORT[/PROTOCOL][@NODEFILTER]`)\n - Example: `k3d node edit k3d-mycluster-serverlb --port-add 8080:80`")
-	cmd.Flags().StringArray("port-delete", nil, "[EXPERIMENTAL] Delete a port mapping with the given format\nThe mapping spec needs to be exactly the same as the one used during creation\n - Example: `k3d node edit k3d-mycluster-serverlb --port-delete 8080:80`")
+	cmd.Flags().StringArray("port-add", nil, "Map ports from the node containers (via the serverlb) to the host (Format: `[HOST:][HOSTPORT:]CONTAINERPORT[/PROTOCOL][@NODEFILTER]`)\n - Example: `k3d cluster edit k3d-mycluster-serverlb --port-add 8080:80`")
+	cmd.Flags().StringArray("port-delete", nil, "[EXPERIMENTAL] Delete a port mapping with the given format\nThe mapping spec needs to be exactly the same as the one used during creation\n - Example: `k3d cluster edit k3d-mycluster-serverlb --port-delete 8080:80`")
 
 	// done
 	return cmd

--- a/cmd/node/nodeEdit.go
+++ b/cmd/node/nodeEdit.go
@@ -58,6 +58,7 @@ func NewCmdNodeEdit() *cobra.Command {
 
 	// add flags
 	cmd.Flags().StringArray("port-add", nil, "[EXPERIMENTAL] (serverlb only!) Map ports from the node container to the host (Format: `[HOST:][HOSTPORT:]CONTAINERPORT[/PROTOCOL][@NODEFILTER]`)\n - Example: `k3d node edit k3d-mycluster-serverlb --port-add 8080:80`")
+	cmd.Flags().StringArray("port-delete", nil, "[EXPERIMENTAL] (serverlb only!) Remove port mappings between a node and the host (Format: `[HOST:][HOSTPORT:]CONTAINERPORT[/PROTOCOL][@NODEFILTER]`)\n - Example: `k3d node edit k3d-mycluster-serverlb --port-delete 8080:80`")
 
 	// done
 	return cmd
@@ -65,6 +66,7 @@ func NewCmdNodeEdit() *cobra.Command {
 
 // parseEditNodeCmd parses the command input into variables required to delete nodes
 func parseEditNodeCmd(cmd *cobra.Command, args []string) (*k3d.Node, *client.NodeEditChangeset) {
+
 	existingNode, err := client.NodeGet(cmd.Context(), runtimes.SelectedRuntime, &k3d.Node{Name: args[0]})
 	if err != nil {
 		l.Log().Fatalln(err)
@@ -80,18 +82,25 @@ func parseEditNodeCmd(cmd *cobra.Command, args []string) (*k3d.Node, *client.Nod
 	}
 
 	changeset := &client.NodeEditChangeset{}
+	changeset.Ports = make(map[nat.Port][]client.NodeEditPortBinding)
 
-	/*
-	 * --port-add
-	 */
-	portFlags, err := cmd.Flags().GetStringArray("port-add")
-	if err != nil {
-		l.Log().Errorln(err)
-		return nil, nil
+	portsAdded := parsePortChangeFlag(cmd, changeset, "port-add", false)
+
+	portsDeleted := parsePortChangeFlag(cmd, changeset, "port-delete", true)
+
+	if portsAdded && portsDeleted {
+		l.Log().Fatalln("Cannot combine port addition and deletion")
 	}
 
-	// init portmap
-	changeset.Ports = make(map[nat.Port][]client.NodeEditPortBinding)
+	return existingNode, changeset
+}
+
+func parsePortChangeFlag(cmd *cobra.Command, changeset *client.NodeEditChangeset, flagName string, isRemoval bool) bool {
+
+	portFlags, err := cmd.Flags().GetStringArray(flagName)
+	if err != nil {
+		l.Log().Fatalln(err)
+	}
 
 	for _, flag := range portFlags {
 		portmappings, err := nat.ParsePortSpec(flag)
@@ -101,9 +110,9 @@ func parseEditNodeCmd(cmd *cobra.Command, args []string) (*k3d.Node, *client.Nod
 
 		for _, pm := range portmappings {
 			changeset.Ports[pm.Port] = append(changeset.Ports[pm.Port],
-				client.NodeEditPortBinding{PortBinding: pm.Binding, RemovalFlag: false})
+				client.NodeEditPortBinding{PortBinding: pm.Binding, RemovalFlag: isRemoval})
 		}
 	}
 
-	return existingNode, changeset
+	return len(portFlags) > 0
 }

--- a/pkg/client/cluster.go
+++ b/pkg/client/cluster.go
@@ -1239,7 +1239,7 @@ func ClusterEditChangesetSimple(ctx context.Context, runtime k3drt.Runtime, clus
 		// 2. transform
 		cluster.ServerLoadBalancer = lbChangeset // we're working with pointers, so let's point to the changeset here to not update the original that we keep as a reference
 		if err := TransformPorts(ctx, runtime, cluster, changeset.Ports); err != nil {
-			return fmt.Errorf("error transforming port config %s: %w", changeset.Ports, err)
+			return fmt.Errorf("error transforming port config %+v: %w", changeset.Ports, err)
 		}
 	}
 

--- a/pkg/client/loadbalancer.go
+++ b/pkg/client/loadbalancer.go
@@ -271,7 +271,7 @@ func loadbalancerRemovePortConfigs(loadbalancer *k3d.Loadbalancer, portmapping n
 	for _, nodename := range nodenames {
 		loadbalancer.Config.Ports[portconfig] = util.RemoveFirst(loadbalancer.Config.Ports[portconfig], nodename)
 		if 0 == len(loadbalancer.Config.Ports[portconfig]) {
-			// deleting the empty map entry to get rid of the Docker-level port mapping
+			// deleting the empty map entry to get rid of an invalid Docker-level port mapping it leaves
 			delete(loadbalancer.Config.Ports, portconfig)
 		}
 	}

--- a/pkg/client/ports.go
+++ b/pkg/client/ports.go
@@ -86,7 +86,7 @@ func TransformPorts(ctx context.Context, runtime runtimes.Runtime, cluster *k3d.
 				changePortMappings(cluster.ServerLoadBalancer.Node, portmappings, removalFlag)
 				for _, pm := range portmappings {
 					if err := changeLBPortConfigs(cluster.ServerLoadBalancer, pm, nodes, removalFlag); err != nil {
-						return fmt.Errorf("error adding port config to loadbalancer: %w", err)
+						return fmt.Errorf("error modifying loadbalancer port config : %w", err)
 					}
 				}
 			} else if suffix == "direct" {

--- a/pkg/client/ports.go
+++ b/pkg/client/ports.go
@@ -151,7 +151,7 @@ func removePortMappings(node *k3d.Node, portmappings []nat.PortMapping) {
 		}
 		node.Ports[pm.Port] = util.RemoveFirst(bindings, pm.Binding)
 		if 0 == len(node.Ports[pm.Port]) {
-			// deleting the empty map entry to get rid of the Docker-level port mapping
+			// deleting the empty map entry to get rid of an invalid Docker-level port mapping it leaves
 			delete(node.Ports, pm.Port)
 		}
 	}

--- a/pkg/config/v1alpha5/types.go
+++ b/pkg/config/v1alpha5/types.go
@@ -66,6 +66,7 @@ type VolumeWithNodeFilters struct {
 type PortWithNodeFilters struct {
 	Port        string   `mapstructure:"port" json:"port,omitempty"`
 	NodeFilters []string `mapstructure:"nodeFilters" json:"nodeFilters,omitempty"`
+	Removal     bool     `mapstructure:"removal" json:"removal,omitempty"`
 }
 
 type LabelWithNodeFilters struct {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -37,3 +37,12 @@ func ReplaceInAllElements(replacer *strings.Replacer, arr []string) []string {
 	}
 	return arr
 }
+
+func RemoveFirst[T comparable](slice []T, element T) []T {
+	for i, v := range slice {
+		if v == element {
+			return append(slice[:i], slice[i+1:]...)
+		}
+	}
+	return slice
+}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -38,10 +38,14 @@ func ReplaceInAllElements(replacer *strings.Replacer, arr []string) []string {
 	return arr
 }
 
+func RemoveByIndex[T comparable](slice []T, index int) []T {
+	return append(slice[:index], slice[index+1:]...)
+}
+
 func RemoveFirst[T comparable](slice []T, element T) []T {
 	for i, v := range slice {
 		if v == element {
-			return append(slice[:i], slice[i+1:]...)
+			return RemoveByIndex(slice, i)
 		}
 	}
 	return slice


### PR DESCRIPTION
- purely additive change, a new flag, implementing [1570](https://github.com/k3d-io/k3d/issues/1570).
- tested with all possible node filters, as well as port ranges.   node suffixes seem to be disallowed in the `cluster edit` command.
- the `PortWithNodeFilters` type was already quite case-specific one, so i figured adding the flag there to carry it deeper into the code was acceptable.