### PR TITLE
bug(https://github.com/k3d-io/k3d/issues/1617) : a change in the implementation of feat(1406);

### DIFF
--- a/cmd/cluster/clusterCreate.go
+++ b/cmd/cluster/clusterCreate.go
@@ -254,6 +254,9 @@ func NewCmdClusterCreate() *cobra.Command {
 	cmd.Flags().String("registry-create", "", "Create a k3d-managed registry and connect it to the cluster (Format: `NAME[:HOST][:HOSTPORT]`\n - Example: `k3d cluster create --registry-create mycluster-registry:0.0.0.0:5432`")
 	_ = ppViper.BindPFlag("cli.registries.create", cmd.Flags().Lookup("registry-create"))
 
+	cmd.Flags().Bool("enforce-registry-port-match", false, "Make the internal registry port match the external one")
+	_ = ppViper.BindPFlag("cli.registries.create.enforcePortMatch", cmd.Flags().Lookup("enforce-registry-port-match"))
+
 	cmd.Flags().StringArray("host-alias", nil, "Add `ip:host[,host,...]` mappings")
 	_ = ppViper.BindPFlag("hostaliases", cmd.Flags().Lookup("host-alias"))
 
@@ -328,9 +331,6 @@ func NewCmdClusterCreate() *cobra.Command {
 	/* Registry */
 	cmd.Flags().StringArray("registry-use", nil, "Connect to one or more k3d-managed registries running locally")
 	_ = cfgViper.BindPFlag("registries.use", cmd.Flags().Lookup("registry-use"))
-
-	cmd.Flags().Bool("enforce-registry-port-match", false, "Make the internal registry port match the external one")
-	_ = cfgViper.BindPFlag("registries.create.enforcePortMatch", cmd.Flags().Lookup("enforce-registry-port-match"))
 
 	cmd.Flags().String("registry-config", "", "Specify path to an extra registries.yaml file")
 	_ = cfgViper.BindPFlag("registries.config", cmd.Flags().Lookup("registry-config"))
@@ -576,6 +576,7 @@ func applyCLIOverrides(cfg conf.SimpleConfig) (conf.SimpleConfig, error) {
 		if cfg.Registries.Create == nil {
 			cfg.Registries.Create = &conf.SimpleConfigRegistryCreateConfig{}
 		}
+		cfg.Registries.Create.EnforcePortMatch = ppViper.GetBool("cli.registries.create.enforcePortMatch")
 		cfg.Registries.Create.Name = fvSplit[0]
 		if len(fvSplit) > 1 {
 			exposeAPI, err = cliutil.ParsePortExposureSpec(fvSplit[1], k3d.DefaultRegistryPort, cfg.Registries.Create.EnforcePortMatch)


### PR DESCRIPTION
fixes [1617](https://github.com/k3d-io/k3d/issues/1617) : the flag previously declared within `cfgViper` caused instantiation of a registry creation object (just to set the flag default value), which triggered the attempt to create a registry each time the `cluster create` command gets invoked, even when not needed.

i dun goofed not noticing the warning log lines.

now the port enforcement CLI flag will be considered only if a registry is to be created from the command line. the environment variable changed to `K3D_CLI_REGISTRIES_CREATE_ENFORCEPORTMATCH`. the config file flows work as well, as far as i tested.

mixing the port enforcement CLI flag with the config file won't work, but i'd rather not go that way, the number of combinations is already high.