### PR TITLE
k3d with podman remote does not need DOCKER_SOCK

### DIFF
--- a/docs/usage/advanced/podman.md
+++ b/docs/usage/advanced/podman.md
@@ -88,8 +88,7 @@ Reference: [https://rootlesscontaine.rs/getting-started/common/cgroup2/#enabling
 [Start Podman on the remote host](https://github.com/containers/podman/blob/main/docs/tutorials/remote_client.md), and then set `DOCKER_HOST` when running k3d:
 
 ```
-export DOCKER_HOST=ssh://username@hostname
-export DOCKER_SOCK=/run/user/1000/podman/podman.sock
+export DOCKER_HOST=ssh://username@hostname/run/user/1000/podman/podman.sock
 k3d cluster create
 ```
 


### PR DESCRIPTION
# What

The remote podman section in the advanced usage docs did not work for me. Changing DOCKER_HOST to `export DOCKER_HOST=ssh://username@hostname/run/user/1000/podman/podman.sock` did.

# Why

When using k3d with a remote podman socket, it seems to be necessary to set DOCKER_HOST to a combination of DOCKER_HOST and DOCKER_SOCK

# Implications

This has the potential to improve the docs. I was not able to confirm if this is an issue only relevant to my setup or to others as well.

``` bash
k3d version v5.8.3
k3s version v1.31.5-k3s1 (default)
```

``` bash
Client:        Podman Engine
Version:       5.6.2
API Version:   5.6.2
Go Version:    go1.25.1 X:nodwarf5
Git Commit:    9dd5e1ed33830612bc200d7a13db00af6ab865a4
Built:         Tue Sep 30 00:00:00 2025
Build Origin:  Fedora Project
OS/Arch:       linux/amd64
```