### PR TITLE
image import: fallback to crictl pull when ctr import fails with missing digest

### DIFF
--- a/pkg/client/pull.go
+++ b/pkg/client/pull.go
@@ -1,0 +1,45 @@
+package client
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/k3d-io/k3d/v5/pkg/runtimes"
+	k3d "github.com/k3d-io/k3d/v5/pkg/types"
+)
+
+func importWithPull(ctx context.Context, runtime runtimes.Runtime, cluster *k3d.Cluster, images []string) error {
+	var wg sync.WaitGroup
+	errCh := make(chan error, len(images)*len(cluster.Nodes))
+
+	for _, node := range cluster.Nodes {
+		if node.Role != k3d.ServerRole && node.Role != k3d.AgentRole {
+			continue
+		}
+		for _, img := range images {
+			wg.Add(1)
+			go func(n *k3d.Node, imageRef string) {
+				defer wg.Done()
+
+				// Use ctr; fully-qualified refs are safest
+				cmd := []string{"crictl", "pull", imageRef}
+				if err := runtime.ExecInNode(ctx, n, cmd); err != nil {
+					errCh <- fmt.Errorf("node %s: pull %s failed: %w", n.Name, imageRef, err)
+				}
+			}(node, img)
+		}
+	}
+
+	wg.Wait()
+	close(errCh)
+
+	var errs []error
+	for e := range errCh {
+		errs = append(errs, e)
+	}
+	if len(errs) > 0 {
+		return fmt.Errorf("pull-based import had %d error(s): %v", len(errs), errs)
+	}
+	return nil
+}

--- a/pkg/client/tools.go
+++ b/pkg/client/tools.go
@@ -62,6 +62,7 @@ func ImageImportIntoClusterMulti(ctx context.Context, runtime runtimes.Runtime, 
 
 	switch opts.Mode {
 	case k3d.ImportModeAutoDetect:
+		opts.FallbackPull = true
 		if err != nil {
 			return fmt.Errorf("failed to retrieve container runtime information: %w", err)
 		}
@@ -74,6 +75,11 @@ func ImageImportIntoClusterMulti(ctx context.Context, runtime runtimes.Runtime, 
 		loadWithToolsNode = true
 	case k3d.ImportModeDirect:
 		loadWithToolsNode = false
+	case k3d.ImageImportModePull:
+		if len(imagesFromTar) > 0 {
+			return fmt.Errorf("pull mode doesn't support tar inputs")
+		}
+		return importWithPull(ctx, runtime, cluster, imagesFromRuntime)
 	}
 
 	/* TODO:
@@ -97,6 +103,14 @@ func ImageImportIntoClusterMulti(ctx context.Context, runtime runtimes.Runtime, 
 	return nil
 }
 
+func isMissingDigestErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	s := err.Error()
+	return strings.Contains(s, "content digest sha256:") && strings.Contains(s, "not found")
+}
+
 func importWithToolsNode(ctx context.Context, runtime runtimes.Runtime, cluster *k3d.Cluster, imagesFromRuntime []string, imagesFromTar []string, opts k3d.ImageImportOpts) error {
 	// create tools node to export images
 	toolsNode, err := EnsureToolsNode(ctx, runtime, cluster)
@@ -104,7 +118,10 @@ func importWithToolsNode(ctx context.Context, runtime runtimes.Runtime, cluster 
 		return fmt.Errorf("failed to ensure that tools node is running: %w", err)
 	}
 
-	var importTarNames []string
+	var (
+		importTarNames []string
+		copyErrs       []error
+	)
 
 	if len(imagesFromRuntime) > 0 {
 		// save image to tarfile in shared volume
@@ -122,12 +139,15 @@ func importWithToolsNode(ctx context.Context, runtime runtimes.Runtime, cluster 
 		for _, file := range imagesFromTar {
 			tarName := fmt.Sprintf("%s/k3d-%s-images-%s-file-%s", k3d.DefaultImageVolumeMountPath, cluster.Name, time.Now().Format("20060102150405"), path.Base(file))
 			if err := runtime.CopyToNode(ctx, file, tarName, toolsNode); err != nil {
+				copyErrs = append(copyErrs, fmt.Errorf("failed to copy image tar '%s' to tools node: %w", file, err))
 				l.Log().Errorf("failed to copy image tar '%s' to tools node! Error below:\n%+v", file, err)
 				continue
 			}
 			importTarNames = append(importTarNames, tarName)
 		}
 	}
+
+	errCh := make(chan error, len(importTarNames)*len(cluster.Nodes))
 
 	// import image in each node
 	l.Log().Infoln("Importing images into nodes...")
@@ -141,6 +161,21 @@ func importWithToolsNode(ctx context.Context, runtime runtimes.Runtime, cluster 
 					l.Log().Infof("Importing images from tarball '%s' into node '%s'...", tarPath, node.Name)
 					if err := runtime.ExecInNode(ctx, node, []string{"ctr", "image", "import", "--all-platforms", tarPath}); err != nil {
 						l.Log().Errorf("failed to import images in node '%s': %v", node.Name, err)
+						if opts.FallbackPull && isMissingDigestErr(err) && len(imagesFromRuntime) > 0 {
+							l.Log().Warnf("tar import failed in node '%s' due to missing digest; falling back to pull", node.Name)
+
+							// pull each runtime image into this node
+							for _, img := range imagesFromRuntime {
+								pullCmd := []string{"crictl", "pull", img}
+								if pullErr := runtime.ExecInNode(ctx, node, pullCmd); pullErr != nil {
+									errCh <- fmt.Errorf("node %s: import failed (%v) and pull fallback failed for %s: %w",
+										node.Name, err, img, pullErr)
+									return
+								}
+							}
+							// fallback succeeded, so treat as success
+							return
+						}
 					}
 					wg.Done()
 				}(node, &importWaitgroup, tarName)
@@ -148,6 +183,7 @@ func importWithToolsNode(ctx context.Context, runtime runtimes.Runtime, cluster 
 		}
 	}
 	importWaitgroup.Wait()
+	close(errCh)
 
 	// remove tarball
 	if !opts.KeepTar && len(importTarNames) > 0 {
@@ -164,6 +200,18 @@ func importWithToolsNode(ctx context.Context, runtime runtimes.Runtime, cluster 
 			l.Log().Errorf("failed to delete tools node '%s' (try to delete it manually): %v", toolsNode.Name, err)
 		}
 	}
+
+	var importErrs []error
+	for e := range errCh {
+		importErrs = append(importErrs, e)
+	}
+	allErrs := append(copyErrs, importErrs...)
+	if len(allErrs) > 0 {
+		// Go 1.20+: return errors.Join(allErrs...)
+		// Compatible fallback:
+		return fmt.Errorf("image import encountered %d error(s): %v", len(allErrs), allErrs)
+	}
+
 	return nil
 }
 

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -197,6 +197,7 @@ const (
 	ImportModeAutoDetect ImportMode = "auto"
 	ImportModeDirect     ImportMode = "direct"
 	ImportModeToolsNode  ImportMode = "tools-node"
+	ImageImportModePull  ImportMode = "pull"
 )
 
 // ImportModes defines the loading methods for image loading
@@ -204,6 +205,7 @@ var ImportModes = map[string]ImportMode{
 	string(ImportModeAutoDetect): ImportModeAutoDetect,
 	string(ImportModeDirect):     ImportModeDirect,
 	string(ImportModeToolsNode):  ImportModeToolsNode,
+	string(ImageImportModePull):  ImageImportModePull,
 }
 
 // ImageImportOpts describes a set of options one can set for loading image(s) into cluster(s)
@@ -211,6 +213,7 @@ type ImageImportOpts struct {
 	KeepTar       bool
 	KeepToolsNode bool
 	Mode          ImportMode
+	FallbackPull  bool
 }
 
 type IPAM struct {


### PR DESCRIPTION
### What
Adds an optional fallback to `crictl pull` when `ctr images import` fails
with `content digest sha256:... not found`.

### Why
When Docker Desktop uses the containerd image store, `k3d image import`
may export tarballs referencing missing blobs, causing import failures
(see #1538).

This change:
- preserves existing behavior by default
- adds another mode via `--mode=pull`
- avoids reporting false success

### Scope
- v5.x compatible

### Related issues
Fixes / mitigates #1538