### PR TITLE
fix(client/cluster): try to create registry even registry-use paramet…

### DIFF
--- a/pkg/client/cluster.go
+++ b/pkg/client/cluster.go
@@ -175,8 +175,8 @@ func ClusterPrep(ctx context.Context, runtime k3drt.Runtime, clusterConfig *conf
 		*reg = *regFromNode
 	}
 
-	// Create managed registry bound to this cluster
-	if clusterConfig.ClusterCreateOpts.Registries.Create != nil {
+	// Create managed registry bound to this cluster if not already created (podman usecase)
+	if clusterConfig.ClusterCreateOpts.Registries.Use == nil && clusterConfig.ClusterCreateOpts.Registries.Create != nil {
 		registryNode, err := RegistryCreate(ctx, runtime, clusterConfig.ClusterCreateOpts.Registries.Create)
 		if err != nil {
 			return fmt.Errorf("Failed to create registry: %+v", err)


### PR DESCRIPTION
…er set



<!-- 
Hi there, have an early THANK YOU for your contribution!
k3d is a community-driven project, so we really highly appreciate any support.
Please make sure, you've read our Code of Conduct and the Contributing Guidelines :)
- Code of Conduct: https://github.com/k3d-io/k3d/blob/main/CODE_OF_CONDUCT.md
- Contributing Guidelines: https://github.com/k3d-io/k3d/blob/main/CONTRIBUTING.md
-->

# What

<!-- What does this PR do or change? -->
Using podman as desscribed in _docs/usage/advanced/podman.md_, cluster creation needs 2 commands:

    # Create the registry
    k3d registry create --network=podman mycluster-registry
    # Create the cluster
    k3d cluster create --registry-use mycluster-registry mycluster

Even the option `--registry-use` is passed to the commandline, k3d tries to create the registry and the command failed with message

    ERRO[0000] Failed Cluster Preparation: Failed to create registry: A registry node with that name already exists

Update the test case to create the registry.

# Why

<!-- Link issues, discussions, etc. or just explain why you're creating this PR -->

Correct an issue #1642 

# Implications

<!--
Does this change existing behavior? If so, does it affect the CLI (cmd/) only or does it also/only change some internals of the Go module (pkg/)?
Especially mention breaking changes here!
-->

<!-- Get recognized using our all-contributors bot: https://github.com/k3d-io/k3d/blob/main/CONTRIBUTING.md#get-recognized -->
