### PR TITLE
fix(entrypoint): skip drain/uncordon on agent nodes

### DIFF
--- a/pkg/types/fixes/assets/k3d-entrypoint.sh
+++ b/pkg/types/fixes/assets/k3d-entrypoint.sh
@@ -16,21 +16,39 @@ done
 
 echo "[$(date -Iseconds)] Finished k3d entrypoint scripts!" >> "$LOGFILE"
 
+# Capture the k3s subcommand ("server" or "agent") before starting k3s.
+# We need this in a variable because $1 inside functions refers to the
+# function's arguments, not the script's.
+K3S_ROLE="${1:-}"
+
 /bin/k3s "$@" &
 k3s_pid=$!
 
-# shellcheck disable=SC3028
-until kubectl uncordon "$HOSTNAME"; do sleep 3; done
+# Only server nodes have a kubeconfig at /etc/rancher/k3s/k3s.yaml that
+# grants kubectl API access. Agent nodes have no usable kubeconfig, so
+# running kubectl commands on them fails in an infinite retry loop (#1420,
+# #1535). Drain/uncordon is also semantically a server-side scheduling
+# operation — agents don't need to drain themselves.
+#
+# We match "server" explicitly rather than excluding "agent" so that any
+# unexpected value (manual docker run, future k3s subcommands) falls
+# through to the safe default: SIGTERM forwarding only.
+if [ "$K3S_ROLE" = "server" ]; then
+  # shellcheck disable=SC3028
+  until kubectl uncordon "$HOSTNAME"; do sleep 3; done
+fi
 
 # shellcheck disable=SC3028
 cleanup() {
-  echo Draining node...
-  kubectl drain "$HOSTNAME" --force --delete-emptydir-data --ignore-daemonsets --disable-eviction
-  echo Sending SIGTERM to k3s...
+  if [ "$K3S_ROLE" = "server" ]; then
+    echo "Draining node..."
+    kubectl drain "$HOSTNAME" --force --delete-emptydir-data --ignore-daemonsets --disable-eviction
+  fi
+  echo "Sending SIGTERM to k3s..."
   kill -15 $k3s_pid
-  echo Waiting for k3s to close...
+  echo "Waiting for k3s to close..."
   wait $k3s_pid
-  echo Bye!
+  echo "Bye!"
 }
 
 # shellcheck disable=SC3048


### PR DESCRIPTION
# What

Skip `kubectl uncordon` and `kubectl drain` on agent nodes in `k3d-entrypoint.sh`. Only server nodes run drain/uncordon; agents get clean SIGTERM forwarding only.

Also captures `$1` into a `K3S_ROLE` variable at script scope, since `$1` inside a shell function refers to the function's arguments, not the script's. Without this, `set -o nounset` would crash when the trap fires on shutdown.

# Why

PR #1119 added graceful drain/uncordon to the entrypoint, but it runs unconditionally on all node types. Agent nodes don't have a kubeconfig at the default path (`/etc/rancher/k3s/k3s.yaml`), so `kubectl` falls back to `localhost:8080` and retries forever, spamming agent logs from the moment the node starts.

Fixes #1420, #1535
May also help with #1526, #1452 (multi-server restart hangs)

# Implications

This changes behavior for agent nodes only. Server nodes are unaffected and still drain on shutdown and uncordon on start, exactly as before.

The change is in `pkg/types/fixes/assets/k3d-entrypoint.sh` (embedded shell script). No Go code changes. No CLI changes.

We match `$1 = "server"` explicitly rather than excluding `"agent"`, so any unexpected value (e.g. someone running the container image directly with arbitrary args) falls through to the safe default of SIGTERM forwarding only.

# Testing

Tested locally against `k3s v1.34.3+k3s3` with a patched binary (`make build` re-embeds the script via `//go:embed`).

**$1 validation:** Confirmed via `docker inspect --format '{{json .Config.Cmd}}'` that server containers receive `["server", ...]` and agent containers receive `["agent"]`.

**1 server + 1 agent cluster:**
- Agent logs: zero `localhost:8080` errors (was infinite loop before this fix)
- Both nodes Ready, cluster functional

**Graceful shutdown (cluster stop):**
- Server logs: `Draining node...` (drain ran as expected)
- Agent logs: `Sending SIGTERM to k3s...` / `Waiting for k3s to close...` / `Bye!` (no drain, clean exit)
- Cluster restarted cleanly, both nodes back to Ready

**3 servers + 2 agents:**
- All 5 nodes Ready on create
- Both agents: zero `localhost:8080` errors
- Cluster stop: all 3 servers drained, both agents SIGTERM-only
- Cluster restart: all 5 nodes back to Ready
