### PR TITLE
docs: update podman guide

### DIFF
--- a/docs/usage/advanced/podman.md
+++ b/docs/usage/advanced/podman.md
@@ -1,97 +1,102 @@
 # Using Podman instead of Docker
 
-Podman has an [Docker API compatibility layer](https://podman.io/blogs/2020/06/29/podman-v2-announce.html#restful-api). k3d uses the Docker API and is compatible with Podman v4 and higher.
+Podman has an [Docker API compatibility layer](https://podman.io/blogs/2020/06/29/podman-v2-announce.html#restful-api).  
+k3d uses the Docker API and is compatible with Podman v4 and higher.
 
 !!! important "Podman support is experimental"
     k3d is not guaranteed to work with Podman. If you find a bug, do help by [filing an issue](https://github.com/k3d-io/k3d/issues/new?labels=bug&template=bug_report.md&title=%5BBUG%5D+Podman)
 
-Tested with podman version:
-```bash
-Client:       Podman Engine
-Version:      4.3.1
-API Version:  4.3.1
+Tested with:
+```
+podman version 5.7.0
+k3d version v5.8.3
 ```
 
-## Using Podman
+## Basic Setup
 
-Ensure the Podman system socket is available:
-
-```bash
-sudo systemctl enable --now podman.socket
-# or to start the socket daemonless
-# sudo podman system service --time=0 &
-```
-
-Disable timeout for podman service:<br>
-See the [podman-system-service (1)](https://docs.podman.io/en/latest/markdown/podman-system-service.1.html) man page for more information.
-```bash
-mkdir -p /etc/containers/containers.conf.d
-echo 'service_timeout=0' > /etc/containers/containers.conf.d/timeout.conf
-```
-
-To point k3d at the right Docker socket, create a symbolic link:
+Ensure the Podman system socket is available and exposed with the environment variable `DOCKER_HOST`.
 
 ```bash
-sudo ln -s /run/podman/podman.sock /var/run/docker.sock
-# or install your system podman-docker if available
-sudo k3d cluster create
+export XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}"
+export DOCKER_HOST="unix://${XDG_RUNTIME_DIR}/podman/podman.sock"
 ```
-
-Alternatively, set `DOCKER_HOST` when running k3d:
-
+or using rootful podman:
 ```bash
 export DOCKER_HOST=unix:///run/podman/podman.sock
-export DOCKER_SOCK=/run/podman/podman.sock
-sudo --preserve-env=DOCKER_HOST --preserve-env=DOCKER_SOCK k3d cluster create
 ```
 
-### Using rootless Podman
-
-Ensure the Podman user socket is available:
+The socket should be enabled per-default on your system if you have installed podman properly.
+You can check if the socket exists with
 
 ```bash
-systemctl --user enable --now podman.socket
-# or podman system service --time=0 &
+ls "${DOCKER_HOST#unix://}"
 ```
 
-Set `DOCKER_HOST` when running k3d:
+If the file does not show up you can start a rootless podman service with
 
 ```bash
-XDG_RUNTIME_DIR=${XDG_RUNTIME_DIR:-/run/user/$(id -u)}
-export DOCKER_HOST=unix://$XDG_RUNTIME_DIR/podman/podman.sock
-export DOCKER_SOCK=$XDG_RUNTIME_DIR/podman/podman.sock
-k3d cluster create
+podman system service --time 0
 ```
 
-#### Using cgroup (v2)
+## Rootless Setup
 
-By default, a non-root user can only get memory controller and pids controller to be delegated.
+Rootless podman requires some additional setup to run k3d.
 
-To run properly we need to enable CPU, CPUSET, and I/O delegation
+### Using cgroup v2
 
-!!! note "Make sure you're running cgroup v2"
-    If `/sys/fs/cgroup/cgroup.controllers` is present on your system, you are using v2, otherwise you are using v1.
+If you are running cgroup v2, you need to delegate some control groups to normal user processes.
+You are using cgroup v2 if `/sys/fs/cgroup/cgroup.controllers` exists.
 
 ```bash
-mkdir -p /etc/systemd/system/user@.service.d
-cat > /etc/systemd/system/user@.service.d/delegate.conf <<EOF
+ls /sys/fs/cgroup/cgroup.controllers
+```
+
+If you are using cgroup v2 you can check which control groups your user has access to (systemd):
+
+```bash
+cat /sys/fs/cgroup/user.slice/user-$(id -u).slice/user@$(id -u).service/cgroup.controllers
+```
+
+If your output does not include `cpu`, `cpuset`, `io`, `memory`, `pids` then
+you need to manually delegate control over these from your init system.
+
+In systemd you can do this by adding `Delegate=cpu cpuset io memory pids` to the `user@` service.
+
+`/etc/systemd/system/user@.service.d/delegate.conf`
+```systemd
 [Service]
 Delegate=cpu cpuset io memory pids
-EOF
+```
+```bash
 systemctl daemon-reload
 ```
 
-Reference: [https://rootlesscontaine.rs/getting-started/common/cgroup2/#enabling-cpu-cpuset-and-io-delegation](https://rootlesscontaine.rs/getting-started/common/cgroup2/#enabling-cpu-cpuset-and-io-delegation)
+Reference:  
+- [Guide](https://rootlesscontaine.rs/getting-started/common/cgroup2/#enabling-cpu-cpuset-and-io-delegation)  
+- [cgroup v2 linux kernel docs](https://www.kernel.org/doc/html/latest/admin-guide/cgroup-v2.html)
 
-### Using remote Podman
+### Running the kubelet in rootless mode
 
-[Start Podman on the remote host](https://github.com/containers/podman/blob/main/docs/tutorials/remote_client.md), and then set `DOCKER_HOST` when running k3d:
+You have to inform the k3s kubelet that it should run in rootless mode.  
+You can pass the kubelet argument `--kubelet-arg=feature-gates=KubeletInUserNamespace=true`
 
+```yaml
+options:
+  k3s:
+    extraArgs:
+      - arg: "--kubelet-arg=feature-gates=KubeletInUserNamespace=true"
+        nodeFilters:
+          - server:*
+          - agent:*
 ```
-export DOCKER_HOST=ssh://username@hostname
-export DOCKER_SOCK=/run/user/1000/podman/podman.sock
-k3d cluster create
-```
+
+!!! note "Issues with k3s image before k3d version v5.9"
+    On some distros k3d defaults to the `v1.21.7-k3s1` k3s image which is too old to support this argument.  
+    To make it work anyway you can override the image:
+
+    ```yaml
+    image: docker.io/rancher/k3s:v1.32.5-k3s1
+    ```
 
 ### macOS
 
@@ -151,15 +156,6 @@ export DOCKER_SOCK=/run/podman/podman.sock
 k3d cluster create
 ```
 
-### Podman network
-
-The default `podman` network has dns disabled. To allow k3d cluster nodes to communicate with dns a new network must be created.
-```bash
-podman network create k3d
-podman network inspect k3d -f '{{ .DNSEnabled }}'
-true
-```
-
 ## Creating local registries
 
 Because Podman does not have a default "bridge" network, you have to specify a network using the `--default-network` flag when creating a local registry:
@@ -174,9 +170,10 @@ To use this registry with a cluster, pass the `--registry-use` flag:
 k3d cluster create --registry-use mycluster-registry mycluster
 ```
 
+This flag does not have a k3d config option yet.
+
 !!! note "Incompatibility with `--registry-create`"
     Because `--registry-create` assumes the default network to be "bridge", avoid `--registry-create` when using Podman. Instead, always create a registry before creating a cluster.
 
 !!! note "Missing cpuset cgroup controller"
-    If you experince an error regarding missing cpuset cgroup controller, ensure the user unit `xdg-document-portal.service` is disabled by running `systemctl --user stop xdg-document-portal.service`. See [this issue](https://github.com/systemd/systemd/issues/18293#issuecomment-831397578)
-
+    If you experience an error regarding missing cpuset cgroup controller, ensure the user unit `xdg-document-portal.service` is disabled by running `systemctl --user stop xdg-document-portal.service`. See [this issue](https://github.com/systemd/systemd/issues/18293#issuecomment-831397578)


### PR DESCRIPTION
<!-- 
Hi there, have an early THANK YOU for your contribution!
k3d is a community-driven project, so we really highly appreciate any support.
Please make sure, you've read our Code of Conduct and the Contributing Guidelines :)
- Code of Conduct: https://github.com/k3d-io/k3d/blob/main/CODE_OF_CONDUCT.md
- Contributing Guidelines: https://github.com/k3d-io/k3d/blob/main/CONTRIBUTING.md
-->

This PR updates the documentation on using k3d with podman.

The previous documentation was confusing and did simply not work.
This is reflected by the open github issues of non-working podman configs.

## TODO:
- Someone has to cross-verify that these instructions work
- Update MacOS section

## Open Questions:
- Should we add instructions for init systems other than systemd?

### Should I re-add the section on remote podman?
The main reason the old docs were unreadable to me is due to the `DOCKER_HOST` and `DOCKER_SOCK` clutter. If I have some very basic experience with podman/docker I will know to set those variables as they are not tooling specific. Moreover the `DOCKER_SOCK` variable is not even used.

### MacOS section
I also think the MacOS section should be reduced. The guide clearly explains how to set delegate cpuset for systemd users so mac users should be able to follow along. Users that want to use k3d have probably already setup podman and a general setup guide is out of scope.

I cannot verify changes to the macOS section tho, so I left them untouched for now.

### `--default-network` for creating registries
I understand the necessity regarding extra config for rootless kubelet and cgroup v2 delegation but I think this should simply use the podman network per default if it is detected. Also why is the `--default-network` parameter only there for the `registry create` subcommand but not for the options in `cluster create`.

#1605 seems to be about this, too

### Backport?
Since its only docs related this PR should be back-ported.
The changes were tested on the latest stable version anyway.

Some of these open questions are not specific to this PR. I can open separate issues for them so that this can get merged quickly.

### Clarification on whether cgroup v1 is supported?
There is an open issue because cgroup v1 doesn't work.
I personally can't test that but we should specify whether it is even supported or not?

#1439

### Podman/ at least rootless docker should have first-class support
K3d is clearly more useful when running without root. Why not make it the default/ at least officially supported.

For dev rootless is simply superior:
no sudo for `kubectl` (the config gets merged into root when using `sudo k3d cluster create`)
you can run something like `tilt` with k3d and properly.
devs that don't have root access can use k3d.

## Close 

Please close your resolved issues!
Open issues also serve as documentation the fact that there's so many open ones makes the situation even worse.

- #1105 afaik this should work now? At least when they retry using the new docs
- #1178 can be closed now
- #1082 this should be closed if users retry with the new docs
- #1162 this issue should've already been closed
- #1043 should already be closed
- #1429 ?
- #1380 needs an update (old k3d version)
- #585 extremely old
- #1319 this guy just opened an issue with the issue template
- #1428 probably didn't read the doc
- #1312 the docs address this

<!--
Does this change existing behavior? If so, does it affect the CLI (cmd/) only or does it also/only change some internals of the Go module (pkg/)?
Especially mention breaking changes here!
-->

<!-- Get recognized using our all-contributors bot: https://github.com/k3d-io/k3d/blob/main/CONTRIBUTING.md#get-recognized -->
