### PR TITLE
feat: cluster restart cmd, fix #984

### DIFF
--- a/cmd/cluster/cluster.go
+++ b/cmd/cluster/cluster.go
@@ -43,12 +43,15 @@ func NewCmdCluster() *cobra.Command {
 	}
 
 	// add subcommands
-	cmd.AddCommand(NewCmdClusterCreate(),
+	cmd.AddCommand(
+		NewCmdClusterCreate(),
 		NewCmdClusterStart(),
 		NewCmdClusterStop(),
 		NewCmdClusterDelete(),
+		NewCmdClusterRestart(),
 		NewCmdClusterList(),
-		NewCmdClusterEdit())
+		NewCmdClusterEdit(),
+	)
 
 	// add flags
 

--- a/cmd/cluster/clusterRestart.go
+++ b/cmd/cluster/clusterRestart.go
@@ -22,6 +22,8 @@ THE SOFTWARE.
 package cluster
 
 import (
+	"time"
+
 	"github.com/spf13/cobra"
 
 	"github.com/k3d-io/k3d/v5/cmd/util"
@@ -33,6 +35,10 @@ import (
 
 // NewCmdClusterRestart returns a new cobra command
 func NewCmdClusterRestart() *cobra.Command {
+	startClusterOpts := k3d.ClusterStartOpts{
+		Intent: k3d.IntentClusterStart,
+	}
+
 	// create new command
 	cmd := &cobra.Command{
 		Use:               "restart [NAME [NAME...] | --all]",
@@ -44,10 +50,6 @@ func NewCmdClusterRestart() *cobra.Command {
 			if len(clusters) == 0 {
 				l.Log().Infoln("No clusters found")
 			} else {
-				startClusterOpts := k3d.ClusterStartOpts{
-					Intent: k3d.IntentClusterStart,
-				}
-
 				for _, c := range clusters {
 					l.Log().Infof("Restarting cluster '%s'", c.Name)
 
@@ -77,12 +79,13 @@ func NewCmdClusterRestart() *cobra.Command {
 					l.Log().Infof("Restarted cluster '%s'", c.Name)
 				}
 			}
-			}
 		},
 	}
 
 	// add flags
 	cmd.Flags().BoolP("all", "a", false, "Restart all existing clusters")
+	cmd.Flags().BoolVar(&startClusterOpts.WaitForServer, "wait", true, "Wait for the server(s) (and loadbalancer) to be ready before returning.")
+	cmd.Flags().DurationVar(&startClusterOpts.Timeout, "timeout", 0*time.Second, "Maximum waiting time for '--wait' before canceling/returning.")
 
 	// add subcommands
 

--- a/cmd/cluster/clusterRestart.go
+++ b/cmd/cluster/clusterRestart.go
@@ -74,9 +74,9 @@ func NewCmdClusterRestart() *cobra.Command {
 					if err := client.ClusterStart(cmd.Context(), runtimes.SelectedRuntime, c, startClusterOpts); err != nil {
 						l.Log().Fatalln(err)
 					}
-					l.Log().Infof("Started cluster '%s'", c.Name)
 					l.Log().Infof("Restarted cluster '%s'", c.Name)
 				}
+			}
 			}
 		},
 	}

--- a/cmd/cluster/clusterRestart.go
+++ b/cmd/cluster/clusterRestart.go
@@ -90,7 +90,7 @@ func NewCmdClusterRestart() *cobra.Command {
 	return cmd
 }
 
-// parseRestartClusterCmd parses the command input into variables required to start clusters
+// parseRestartClusterCmd parses the command input into variables required to restart clusters
 func parseRestartClusterCmd(cmd *cobra.Command, args []string) []*k3d.Cluster {
 	// --all
 	var clusters []*k3d.Cluster

--- a/cmd/cluster/clusterRestart.go
+++ b/cmd/cluster/clusterRestart.go
@@ -42,8 +42,8 @@ func NewCmdClusterRestart() *cobra.Command {
 	// create new command
 	cmd := &cobra.Command{
 		Use:               "restart [NAME [NAME...] | --all]",
-		Short:             "restart existing k3d cluster(s)",
-		Long:              `restart existing k3d cluster(s).`,
+		Short:             "Restart existing k3d cluster(s)",
+		Long:              `Restart existing k3d cluster(s).`,
 		ValidArgsFunction: util.ValidArgsAvailableClusters,
 		Run: func(cmd *cobra.Command, args []string) {
 			clusters := parseRestartClusterCmd(cmd, args)

--- a/cmd/cluster/clusterRestart.go
+++ b/cmd/cluster/clusterRestart.go
@@ -1,0 +1,122 @@
+/*
+Copyright © 2020-2023 The k3d Author(s)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package cluster
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/k3d-io/k3d/v5/cmd/util"
+	"github.com/k3d-io/k3d/v5/pkg/client"
+	l "github.com/k3d-io/k3d/v5/pkg/logger"
+	"github.com/k3d-io/k3d/v5/pkg/runtimes"
+	k3d "github.com/k3d-io/k3d/v5/pkg/types"
+)
+
+// NewCmdClusterRestart returns a new cobra command
+func NewCmdClusterRestart() *cobra.Command {
+	// create new command
+	cmd := &cobra.Command{
+		Use:               "restart [NAME [NAME...] | --all]",
+		Short:             "restart existing k3d cluster(s)",
+		Long:              `restart existing k3d cluster(s).`,
+		ValidArgsFunction: util.ValidArgsAvailableClusters,
+		Run: func(cmd *cobra.Command, args []string) {
+			clusters := parseRestartClusterCmd(cmd, args)
+			if len(clusters) == 0 {
+				l.Log().Infoln("No clusters found")
+			} else {
+				startClusterOpts := k3d.ClusterStartOpts{
+					Intent: k3d.IntentClusterStart,
+				}
+
+				for _, c := range clusters {
+					l.Log().Infof("Restarting cluster '%s'", c.Name)
+
+					if err := client.ClusterStop(cmd.Context(), runtimes.SelectedRuntime, c); err != nil {
+						l.Log().Fatalln(err)
+					}
+
+					envInfo, err := client.GatherEnvironmentInfo(cmd.Context(), runtimes.SelectedRuntime, c)
+					if err != nil {
+						l.Log().Fatalf("failed to gather info about cluster environment: %v", err)
+					}
+					startClusterOpts.EnvironmentInfo = envInfo
+
+					// Get pre-defined clusterStartOpts from cluster
+					fetchedClusterStartOpts, err := client.GetClusterStartOptsFromLabels(c)
+					if err != nil {
+						l.Log().Fatalf("failed to get cluster start opts from cluster labels: %v", err)
+					}
+
+					// override only a few clusterStartOpts from fetched opts
+					startClusterOpts.HostAliases = fetchedClusterStartOpts.HostAliases
+
+					// start the cluster
+					if err := client.ClusterStart(cmd.Context(), runtimes.SelectedRuntime, c, startClusterOpts); err != nil {
+						l.Log().Fatalln(err)
+					}
+					l.Log().Infof("Started cluster '%s'", c.Name)
+					l.Log().Infof("Restarted cluster '%s'", c.Name)
+				}
+			}
+		},
+	}
+
+	// add flags
+	cmd.Flags().BoolP("all", "a", false, "Restart all existing clusters")
+
+	// add subcommands
+
+	// done
+	return cmd
+}
+
+// parseRestartClusterCmd parses the command input into variables required to start clusters
+func parseRestartClusterCmd(cmd *cobra.Command, args []string) []*k3d.Cluster {
+	// --all
+	var clusters []*k3d.Cluster
+
+	if all, err := cmd.Flags().GetBool("all"); err != nil {
+		l.Log().Fatalln(err)
+	} else if all {
+		clusters, err = client.ClusterList(cmd.Context(), runtimes.SelectedRuntime)
+		if err != nil {
+			l.Log().Fatalln(err)
+		}
+		return clusters
+	}
+
+	clusternames := []string{k3d.DefaultClusterName}
+	if len(args) != 0 {
+		clusternames = args
+	}
+
+	for _, name := range clusternames {
+		cluster, err := client.ClusterGet(cmd.Context(), runtimes.SelectedRuntime, &k3d.Cluster{Name: name})
+		if err != nil {
+			l.Log().Fatalln(err)
+		}
+		clusters = append(clusters, cluster)
+	}
+
+	return clusters
+}

--- a/cmd/cluster/clusterRestart.go
+++ b/cmd/cluster/clusterRestart.go
@@ -50,11 +50,17 @@ func NewCmdClusterRestart() *cobra.Command {
 			if len(clusters) == 0 {
 				l.Log().Infoln("No clusters found")
 			} else {
-				for _, c := range clusters {
-					l.Log().Infof("Restarting cluster '%s'", c.Name)
+				for _, cluster := range clusters {
+					l.Log().Infof("Restarting cluster '%s'", cluster.Name)
 
-					if err := client.ClusterStop(cmd.Context(), runtimes.SelectedRuntime, c); err != nil {
+					if err := client.ClusterStop(cmd.Context(), runtimes.SelectedRuntime, cluster); err != nil {
 						l.Log().Fatalln(err)
+					}
+
+					// retrive cluster latest status to start
+					c, err := client.ClusterGet(cmd.Context(), runtimes.SelectedRuntime, &k3d.Cluster{Name: cluster.Name})
+					if err != nil {
+						l.Log().Fatalf("failed to get cluster %s: %v", c.Name, err)
 					}
 
 					envInfo, err := client.GatherEnvironmentInfo(cmd.Context(), runtimes.SelectedRuntime, c)


### PR DESCRIPTION
<!-- 
Hi there, have an early THANK YOU for your contribution!
k3d is a community-driven project, so we really highly appreciate any support.
Please make sure, you've read our Code of Conduct and the Contributing Guidelines :)
- Code of Conduct: https://github.com/k3d-io/k3d/blob/main/CODE_OF_CONDUCT.md
- Contributing Guidelines: https://github.com/k3d-io/k3d/blob/main/CONTRIBUTING.md
-->

# What

<!-- What does this PR do or change? -->
Implement cluster restart command.

# Why

<!-- Link issues, discussions, etc. or just explain why you're creating this PR -->
When I using k3d with multi clusters, I often expect a cluster restart command. And I found there a issue https://github.com/k3d-io/k3d/issues/984 mentioned the same thing, so I implement the command based on start&stop command.

# Implications

<!--
Does this change existing behavior? If so, does it affect the CLI (cmd/) only or does it also/only change some internals of the Go module (pkg/)?
Especially mention breaking changes here!
-->

<!-- Get recognized using our all-contributors bot: https://github.com/k3d-io/k3d/blob/main/CONTRIBUTING.md#get-recognized -->
