### PR TITLE
chore(renovate): hold docker/cli & docker/docker at v28 major (v29 needs moby/moby migration; CVE-2025-15558 unreachable)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -39,6 +39,20 @@
       "matchPackageNames": [
         "*"
       ]
+    },
+    {
+      "description": "Hold docker/cli and docker/docker at the v28 major. The v29 line moves the Go API onto github.com/moby/moby (redesigned options/result client) and requires migrating pkg/runtimes/docker, so the bump cannot build as-is. The v29 [security] advisory (CVE-2025-15558) is Windows + cli-plugins/manager only and is not reachable from k3d (govulncheck confirms; k3d does not import cli-plugins/manager). Re-enable when migrating to github.com/moby/moby/v2.",
+      "matchManagers": [
+        "gomod"
+      ],
+      "matchPackageNames": [
+        "github.com/docker/cli",
+        "github.com/docker/docker"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "enabled": false
     }
   ],
   "customManagers": [


### PR DESCRIPTION
## What

Add a Renovate rule holding `github.com/docker/cli` and `github.com/docker/docker` at the **v28 major** (disables only the *major* update), until the `github.com/moby/moby/v2` migration is done.

## Why

`docker/cli` v29 moves the Go API onto `github.com/moby/moby` — a **redesigned options/result client** (`ContainerCreate(ctx, ContainerCreateOptions) (ContainerCreateResult, error)`, `Container`→`Summary`, `ContainerJSON`→`InspectResponse`, the `filters` package relocated, error helpers moved, etc.). Adopting it requires migrating `pkg/runtimes/docker`. The automated bump in #1652 therefore cannot compile — its CI is red — and it has sat open.

This rule stops Renovate from re-opening unbuildable v29 PRs while keeping patch/minor updates flowing, and documents the reason inline.

## Is the v29 [security] bump actually required for k3d? No.

#1652 is labelled `[security]` for **CVE-2025-15558** (GHSA-p436-gjf2-799p). That advisory is **Windows + `cli-plugins/manager` only** — quoting it: *"This issue does not impact non-Windows binaries or projects that do not use the plugin manager code."*

k3d does **not** import `github.com/docker/cli/cli-plugins/manager` (it uses `cli/command`, `cli/config`, `cli/connhelper`, `cli/context`, `opts`, `streams`). `govulncheck` reachability analysis confirms the advisory is **not** among k3d's reachable vulnerabilities:

```
$ govulncheck ./...
Vulnerability #1: GO-2026-5039   (Go standard library)
Vulnerability #2: GO-2026-5037   (Go standard library)
Vulnerability #3: GO-2026-4887   github.com/docker/docker   (AuthZ plugin bypass)
Vulnerability #4: GO-2026-4883   github.com/docker/docker   (plugin-priv off-by-one)
# CVE-2025-15558 / GHSA-p436-gjf2-799p is NOT listed — unreachable
```

So the major bump is not security-required for k3d.

## Note on the *reachable* findings (out of scope here)

`govulncheck` does flag two reachable advisories in `github.com/docker/docker` (GO-2026-4887, GO-2026-4883). That module is EOL ("all versions, no known fixed"); the fixes live only in `github.com/moby/moby/v2` (≥ v2.0.0-beta.8 / `docker-v29.3.1`). Addressing those is the same `moby/moby/v2` migration referenced above and is better tracked as its own effort, not a Renovate auto-bump.

Relates to #1652.

