### PR TITLE
fix(image-import): report import failures instead of printing success

### DIFF
--- a/pkg/client/tools.go
+++ b/pkg/client/tools.go
@@ -45,8 +45,11 @@ import (
 func ImageImportIntoClusterMulti(ctx context.Context, runtime runtimes.Runtime, images []string, cluster *k3d.Cluster, opts k3d.ImageImportOpts) error {
 	// stdin case
 	if len(images) == 1 && images[0] == "-" {
-		err := loadImageFromStream(ctx, runtime, os.Stdin, cluster, []string{"stdin"})
-		return fmt.Errorf("failed to load image to cluster from stdin: %v", err)
+		if err := loadImageFromStream(ctx, runtime, os.Stdin, cluster, []string{"stdin"}); err != nil {
+			return fmt.Errorf("failed to load image to cluster from stdin: %w", err)
+		}
+		l.Log().Infoln("Successfully imported image(s)")
+		return nil
 	}
 
 	imagesFromRuntime, imagesFromTar, err := findImages(ctx, runtime, images)

--- a/pkg/client/tools.go
+++ b/pkg/client/tools.go
@@ -24,6 +24,7 @@ package client
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -105,6 +106,8 @@ func importWithToolsNode(ctx context.Context, runtime runtimes.Runtime, cluster 
 	}
 
 	var importTarNames []string
+	// errors that must not abort the import of the remaining images, but still have to be reported in the end
+	var deferredErrs []error
 
 	if len(imagesFromRuntime) > 0 {
 		// save image to tarfile in shared volume
@@ -123,6 +126,8 @@ func importWithToolsNode(ctx context.Context, runtime runtimes.Runtime, cluster 
 			tarName := fmt.Sprintf("%s/k3d-%s-images-%s-file-%s", k3d.DefaultImageVolumeMountPath, cluster.Name, time.Now().Format("20060102150405"), path.Base(file))
 			if err := runtime.CopyToNode(ctx, file, tarName, toolsNode); err != nil {
 				l.Log().Errorf("failed to copy image tar '%s' to tools node! Error below:\n%+v", file, err)
+				// continue with the other tarballs, but remember the failure so we don't report success later on
+				deferredErrs = append(deferredErrs, fmt.Errorf("failed to copy image tar '%s' to tools node: %w", file, err))
 				continue
 			}
 			importTarNames = append(importTarNames, tarName)
@@ -131,23 +136,27 @@ func importWithToolsNode(ctx context.Context, runtime runtimes.Runtime, cluster 
 
 	// import image in each node
 	l.Log().Infoln("Importing images into nodes...")
-	var importWaitgroup sync.WaitGroup
+	var importErrGroup errgroup.Group
 	for _, tarName := range importTarNames {
 		for _, node := range cluster.Nodes {
 			// only import image in server and agent nodes (i.e. ignoring auxiliary nodes like the server loadbalancer)
 			if node.Role == k3d.ServerRole || node.Role == k3d.AgentRole {
-				importWaitgroup.Add(1)
-				go func(node *k3d.Node, wg *sync.WaitGroup, tarPath string) {
-					l.Log().Infof("Importing images from tarball '%s' into node '%s'...", tarPath, node.Name)
-					if err := runtime.ExecInNode(ctx, node, []string{"ctr", "image", "import", "--all-platforms", tarPath}); err != nil {
+				importErrGroup.Go(func() error {
+					l.Log().Infof("Importing images from tarball '%s' into node '%s'...", tarName, node.Name)
+					if err := runtime.ExecInNode(ctx, node, []string{"ctr", "image", "import", "--all-platforms", tarName}); err != nil {
+						// log here as well, so that all failures are visible, not just the first one returned below
 						l.Log().Errorf("failed to import images in node '%s': %v", node.Name, err)
+						return fmt.Errorf("failed to import images in node '%s': %w", node.Name, err)
 					}
-					wg.Done()
-				}(node, &importWaitgroup, tarName)
+					return nil
+				})
 			}
 		}
 	}
-	importWaitgroup.Wait()
+	// cleanup below is done even if the import failed, so we only return the errors at the very end
+	if err := importErrGroup.Wait(); err != nil {
+		deferredErrs = append(deferredErrs, err)
+	}
 
 	// remove tarball
 	if !opts.KeepTar && len(importTarNames) > 0 {
@@ -164,7 +173,7 @@ func importWithToolsNode(ctx context.Context, runtime runtimes.Runtime, cluster 
 			l.Log().Errorf("failed to delete tools node '%s' (try to delete it manually): %v", toolsNode.Name, err)
 		}
 	}
-	return nil
+	return errors.Join(deferredErrs...)
 }
 
 func importWithStream(ctx context.Context, runtime runtimes.Runtime, cluster *k3d.Cluster, imagesFromRuntime []string, imagesFromTar []string) error {

--- a/pkg/client/tools_import_test.go
+++ b/pkg/client/tools_import_test.go
@@ -25,6 +25,8 @@ package client
 import (
 	"context"
 	"errors"
+	"io"
+	"os"
 	"strings"
 	"sync"
 	"testing"
@@ -65,6 +67,17 @@ func (f *fakeToolsRuntime) CopyToNode(_ context.Context, _ string, _ string, _ *
 
 func (f *fakeToolsRuntime) DeleteNode(_ context.Context, _ *k3d.Node) error {
 	return nil
+}
+
+func (f *fakeToolsRuntime) ExecInNodeWithStdin(_ context.Context, node *k3d.Node, _ []string, stdin io.ReadCloser) error {
+	// Consume one chunk so that the writer side of the pipe can make progress.
+	// We deliberately do not read until EOF: loadImageFromStream never closes the pipe writers,
+	// so a full drain would block forever (just like `ctr image import -` waiting for more input).
+	buf := make([]byte, 4096)
+	if _, err := stdin.Read(buf); err != nil && err != io.EOF {
+		return err
+	}
+	return f.execErrByNode[node.Name]
 }
 
 func testCluster() *k3d.Cluster {
@@ -114,5 +127,33 @@ func Test_importWithToolsNode_returnsErrorWhenTarballCopyFails(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "/tmp/images.tar") {
 		t.Errorf("expected error to name the tarball that could not be copied, got: %v", err)
+	}
+}
+
+func Test_ImageImportIntoClusterMulti_succeedsWhenReadingImageFromStdin(t *testing.T) {
+	// given: an image tarball on stdin that imports successfully into every node
+	tarball, err := os.CreateTemp(t.TempDir(), "images-*.tar")
+	if err != nil {
+		t.Fatalf("failed to create temporary tarball: %v", err)
+	}
+	if _, err := tarball.WriteString("not a real tarball, but the runtime is faked anyway"); err != nil {
+		t.Fatalf("failed to write temporary tarball: %v", err)
+	}
+	if _, err := tarball.Seek(0, io.SeekStart); err != nil {
+		t.Fatalf("failed to rewind temporary tarball: %v", err)
+	}
+
+	originalStdin := os.Stdin
+	os.Stdin = tarball
+	t.Cleanup(func() { os.Stdin = originalStdin })
+
+	runtime := &fakeToolsRuntime{execErrByNode: map[string]error{}}
+
+	// when
+	err = ImageImportIntoClusterMulti(context.Background(), runtime, []string{"-"}, testCluster(), k3d.ImageImportOpts{})
+
+	// then
+	if err != nil {
+		t.Errorf("expected no error when the import from stdin succeeds, got: %v", err)
 	}
 }

--- a/pkg/client/tools_import_test.go
+++ b/pkg/client/tools_import_test.go
@@ -1,0 +1,118 @@
+/*
+Copyright © 2020-2023 The k3d Author(s)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+package client
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/k3d-io/k3d/v5/pkg/runtimes"
+	k3d "github.com/k3d-io/k3d/v5/pkg/types"
+)
+
+// fakeToolsRuntime implements just enough of runtimes.Runtime to exercise importWithToolsNode.
+// Methods that are not overridden are not expected to be called and will panic on the embedded nil interface.
+type fakeToolsRuntime struct {
+	runtimes.Runtime
+
+	// execErrByNode returns the error that ExecInNode should produce for a given node name
+	execErrByNode map[string]error
+	// copyErr is returned by every CopyToNode call
+	copyErr error
+
+	mutex     sync.Mutex
+	execCalls []string
+}
+
+func (f *fakeToolsRuntime) GetNode(_ context.Context, node *k3d.Node) (*k3d.Node, error) {
+	// pretend a tools node is already up, so that EnsureToolsNode short-circuits
+	return &k3d.Node{Name: node.Name, State: k3d.NodeState{Running: true}}, nil
+}
+
+func (f *fakeToolsRuntime) ExecInNode(_ context.Context, node *k3d.Node, cmd []string) error {
+	f.mutex.Lock()
+	f.execCalls = append(f.execCalls, node.Name+": "+strings.Join(cmd, " "))
+	f.mutex.Unlock()
+	return f.execErrByNode[node.Name]
+}
+
+func (f *fakeToolsRuntime) CopyToNode(_ context.Context, _ string, _ string, _ *k3d.Node) error {
+	return f.copyErr
+}
+
+func (f *fakeToolsRuntime) DeleteNode(_ context.Context, _ *k3d.Node) error {
+	return nil
+}
+
+func testCluster() *k3d.Cluster {
+	return &k3d.Cluster{
+		Name: "test",
+		Nodes: []*k3d.Node{
+			{Name: "k3d-test-server-0", Role: k3d.ServerRole},
+			{Name: "k3d-test-agent-0", Role: k3d.AgentRole},
+			{Name: "k3d-test-serverlb", Role: k3d.LoadBalancerRole},
+		},
+	}
+}
+
+func Test_importWithToolsNode_returnsErrorWhenImportIntoNodeFails(t *testing.T) {
+	// given: importing into one of the cluster nodes fails
+	runtime := &fakeToolsRuntime{
+		execErrByNode: map[string]error{
+			"k3d-test-agent-0": errors.New("ctr: image import failed"),
+		},
+	}
+
+	// when
+	err := importWithToolsNode(context.Background(), runtime, testCluster(), []string{"alpine:latest"}, nil, k3d.ImageImportOpts{})
+
+	// then
+	if err == nil {
+		t.Fatal("expected an error when importing images into a node fails, but got nil")
+	}
+	if !strings.Contains(err.Error(), "k3d-test-agent-0") {
+		t.Errorf("expected error to name the failing node, got: %v", err)
+	}
+}
+
+func Test_importWithToolsNode_returnsErrorWhenTarballCopyFails(t *testing.T) {
+	// given: copying the image tarball to the tools node fails
+	runtime := &fakeToolsRuntime{
+		execErrByNode: map[string]error{},
+		copyErr:       errors.New("no space left on device"),
+	}
+
+	// when
+	err := importWithToolsNode(context.Background(), runtime, testCluster(), nil, []string{"/tmp/images.tar"}, k3d.ImageImportOpts{})
+
+	// then
+	if err == nil {
+		t.Fatal("expected an error when copying the image tarball fails, but got nil")
+	}
+	if !strings.Contains(err.Error(), "/tmp/images.tar") {
+		t.Errorf("expected error to name the tarball that could not be copied, got: %v", err)
+	}
+}


### PR DESCRIPTION
## What

`k3d image import` prints `Successfully imported image(s)` and exits `0` even when the import failed on every node. This PR makes the failures surface, and fixes a related bug on the stdin path found while writing the tests.

Fixes #1484

## Why

`importWithToolsNode` logged its errors but always returned `nil`, so `ImageImportIntoClusterMulti` fell through to the success message. Two paths were losing errors:

1. **Per-node import** — the `ctr image import` calls ran in a bare `sync.WaitGroup` goroutine whose error was only passed to `l.Log().Errorf`. Nothing propagated it.
2. **Tarball copy** — a failed `CopyToNode` logged and `continue`d, so a tarball that never reached the tools node was silently skipped. If it was the only tarball, the import loop then had nothing to do and still reported success.

This matters most in CI/automation, where the reported exit code is the only signal. Two users on the issue describe hitting it intermittently (roughly 1 run in 10) and working around it with `--mode=direct`.

## Changes

**Commit 1 — `fix(image-import): report failures instead of printing success`**

- per-node imports now run in an `errgroup.Group` instead of a `sync.WaitGroup`, so a failure is returned
- failed tarball copies are recorded, while still continuing with the remaining tarballs
- collected errors are returned only *after* the tarball removal and tools-node cleanup have run, so a failed import doesn't leak resources
- per-node errors are still logged individually, so all failures stay visible and not just the first one returned

**Commit 2 — `fix(image-import): don't report failure when reading from stdin succeeds`**

The stdin branch wrapped its result unconditionally:

```go
err := loadImageFromStream(ctx, runtime, os.Stdin, cluster, []string{"stdin"})
return fmt.Errorf("failed to load image to cluster from stdin: %v", err)
```

so `k3d image import -` returned an error on *every* run, including successful ones — literally `failed to load image to cluster from stdin: %!v(<nil>)`. It's the mirror image of the bug above and sits three lines away, so I fixed it here; happy to split it into its own PR if you'd rather keep this focused.

## Tests

New `pkg/client/tools_import_test.go` covering all three behaviours, each confirmed to fail against the unfixed code first:

- `Test_importWithToolsNode_returnsErrorWhenImportIntoNodeFails`
- `Test_importWithToolsNode_returnsErrorWhenTarballCopyFails`
- `Test_ImageImportIntoClusterMulti_succeedsWhenReadingImageFromStdin`

They use a `fakeToolsRuntime` that embeds `runtimes.Runtime` and overrides only the five methods this path touches, following the existing `FakeRuntimeImageGetter` pattern in `tools_test.go`. Any unexpected runtime call panics rather than silently passing.

`go test ./...` passes; `gofmt` and `go vet` are clean on both files. I wasn't able to run `golangci-lint` locally, so please let CI be the judge there.

## Note for reviewers

While writing the stdin test I hit a pre-existing issue that is **not** addressed here: `loadImageFromStream` never closes its pipe writers, so a consumer that reads to EOF blocks forever. It doesn't deadlock in production only because the real `ExecInNodeWithStdin` returns when the exec exits. The fake reads a single chunk to work around it (see the comment there). Worth a separate issue if you agree it's a problem.
