### PR TITLE
fix(cmd): don't require a container runtime for `k3d version`

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -67,11 +67,28 @@ type VersionInfo struct {
 
 var flags = RootFlags{}
 
+// AnnotationRuntimeNotRequired marks commands that do their job without talking to a container runtime.
+// Those commands must not fail just because there's no runtime around (see #1514).
+const AnnotationRuntimeNotRequired = "k3d.io/runtime-not-required"
+
+// runtimeNotRequired returns the annotation map used to mark a command as not requiring a container runtime
+func runtimeNotRequired() map[string]string {
+	return map[string]string{AnnotationRuntimeNotRequired: ""}
+}
+
+// runtimeInitRequired tells whether the given command needs an initialized container runtime to run
+func runtimeInitRequired(cmd *cobra.Command) bool {
+	_, notRequired := cmd.Annotations[AnnotationRuntimeNotRequired]
+	return !notRequired
+}
+
 func NewCmdK3d() *cobra.Command {
 	// rootCmd represents the base command when called without any subcommands
 	rootCmd := &cobra.Command{
-		Use:   "k3d",
-		Short: "https://k3d.io/ -> Run k3s in Docker!",
+		Use: "k3d",
+		// the root command only prints usage or the version, so it doesn't need a runtime
+		Annotations: runtimeNotRequired(),
+		Short:       "https://k3d.io/ -> Run k3s in Docker!",
 		Long: `https://k3d.io/
 k3d is a wrapper CLI that helps you to easily create k3s clusters inside docker.
 Nodes of a k3d cluster are docker containers running a k3s image.
@@ -123,8 +140,17 @@ All Nodes of a k3d cluster are part of the same docker network.`,
 		},
 	)
 
+	// Initialize the runtime only for the commands that actually need it, so that e.g. `k3d version`
+	// keeps working on machines without a container runtime.
+	// Note: this is inherited by all subcommands that don't define a PersistentPreRun of their own.
+	rootCmd.PersistentPreRun = func(cmd *cobra.Command, args []string) {
+		if runtimeInitRequired(cmd) {
+			initRuntime()
+		}
+	}
+
 	// Init
-	cobra.OnInitialize(initLogging, initRuntime)
+	cobra.OnInitialize(initLogging)
 
 	return rootCmd
 }
@@ -219,9 +245,10 @@ func NewCmdVersion() *cobra.Command {
 	)
 
 	cmd := &cobra.Command{
-		Use:   "version",
-		Short: "Show k3d and default k3s version",
-		Long:  "Show k3d and default k3s version",
+		Use:         "version",
+		Short:       "Show k3d and default k3s version",
+		Long:        "Show k3d and default k3s version",
+		Annotations: runtimeNotRequired(),
 		Run: func(cmd *cobra.Command, args []string) {
 			output, _ := cmd.Flags().GetString("output")
 
@@ -302,11 +329,13 @@ func NewCmdVersionLs() *cobra.Command {
 	flags := Flags{}
 
 	cmd := &cobra.Command{
-		Use:       "list COMPONENT",
-		Aliases:   []string{"ls"},
-		Short:     "List k3d/K3s versions. Component can be one of 'k3d', 'k3s', 'k3d-proxy', 'k3d-tools'.",
-		ValidArgs: []string{"k3d", "k3s", "k3d-proxy", "k3d-tools"},
-		Args:      cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),
+		Use:     "list COMPONENT",
+		Aliases: []string{"ls"},
+		Short:   "List k3d/K3s versions. Component can be one of 'k3d', 'k3s', 'k3d-proxy', 'k3d-tools'.",
+		// the versions are fetched from the image registries, so no container runtime is involved
+		Annotations: runtimeNotRequired(),
+		ValidArgs:   []string{"k3d", "k3s", "k3d-proxy", "k3d-tools"},
+		Args:        cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),
 		Run: func(cmd *cobra.Command, args []string) {
 			repo, ok := imageRepos[args[0]]
 			if !ok {
@@ -422,6 +451,8 @@ func NewCmdCompletion(rootCmd *cobra.Command) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "completion SHELL",
 		Short: "Generate completion scripts for [bash, zsh, fish, powershell | psh]",
+		// completion scripts are generated from the command tree, so no container runtime is involved
+		Annotations: runtimeNotRequired(),
 		Long: `To load completions:
 
 Bash:

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,0 +1,79 @@
+/*
+Copyright © 2020-2023 The k3d Author(s)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+package cmd
+
+import (
+	"testing"
+)
+
+func Test_runtimeInitRequired(t *testing.T) {
+	tests := map[string]struct {
+		givenArgs        []string
+		expectedRequired bool
+	}{
+		"version does not need a container runtime": {
+			givenArgs:        []string{"version"},
+			expectedRequired: false,
+		},
+		"version list only queries image registries": {
+			givenArgs:        []string{"version", "list", "k3s"},
+			expectedRequired: false,
+		},
+		"completion is generated from the command tree alone": {
+			givenArgs:        []string{"completion", "bash"},
+			expectedRequired: false,
+		},
+		"cluster create needs a container runtime": {
+			givenArgs:        []string{"cluster", "create"},
+			expectedRequired: true,
+		},
+		"node list needs a container runtime": {
+			givenArgs:        []string{"node", "list"},
+			expectedRequired: true,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			rootCmd := NewCmdK3d()
+
+			cmd, _, err := rootCmd.Find(tt.givenArgs)
+			if err != nil {
+				t.Fatalf("failed to find command %v: %v", tt.givenArgs, err)
+			}
+
+			if actual := runtimeInitRequired(cmd); actual != tt.expectedRequired {
+				t.Errorf("runtimeInitRequired(%v) = %v, expected %v", tt.givenArgs, actual, tt.expectedRequired)
+			}
+		})
+	}
+}
+
+func Test_runtimeInitRequired_isFalseForRootCommand(t *testing.T) {
+	// `k3d` and `k3d --version` only print usage / the version, so they must not need a runtime either
+	rootCmd := NewCmdK3d()
+
+	if runtimeInitRequired(rootCmd) {
+		t.Error("runtimeInitRequired(rootCmd) = true, expected false")
+	}
+}


### PR DESCRIPTION
## What

`k3d version` fails on machines that have `DOCKER_*` environment variables set but no reachable daemon. This makes it — along with `k3d completion` and `k3d version list` — work without a container runtime.

Fixes #1514

## Why

`initRuntime` is registered through `cobra.OnInitialize`, so it runs for *every* command, including those that never touch a runtime. It calls `runtime.Info()`, which reaches docker/cli's `DockerCli.Client()`:

```go
func (cli *DockerCli) Client() client.APIClient {
	if err := cli.initialize(); err != nil {
		_, _ = fmt.Fprintln(cli.Err(), "Failed to initialize:", err)
		os.Exit(1)
	}
	return cli.client
}
```

Note it doesn't return an error — it calls `os.Exit(1)`. That's why the failure can't be swallowed by the `if err == nil` check in `initRuntime`, and why the reporter saw a hard failure with no k3d-formatted error.

The reported use case is a build pipeline verifying a k3d installation in an image that has the docker CLI (and its env vars) but deliberately no daemon. The current workaround is unsetting every `DOCKER_*` variable before invoking k3d.

## How

Commands can now be annotated as not requiring a runtime:

```go
const AnnotationRuntimeNotRequired = "k3d.io/runtime-not-required"
```

Runtime init moves from `cobra.OnInitialize` to a `PersistentPreRun` on the root command that honours the annotation. Annotated:

| command | why it needs no runtime |
|---|---|
| `k3d` (root) | only prints usage or the version |
| `k3d version` | prints compiled-in version strings |
| `k3d version list` | fetches tags from image registries via `crane` |
| `k3d completion` | generated from the command tree |

Everything else is untouched and still initializes the runtime before running. `PersistentPreRun` runs ahead of `PreRun`/`PreRunE`, so the two commands using `PreRunE` (`cluster create`, `cluster delete`) still get an initialized runtime. No command currently defines its own `PersistentPreRun`, so nothing shadows the root one — worth keeping in mind when adding one in future.

`initLogging` stays in `cobra.OnInitialize` and therefore still runs first, so log level and formatting are configured before any runtime work, as before.

## Verification

Built from `main` and from this branch, using the reporter's scenario:

```
$ export DOCKER_TLS_VERIFY=1 DOCKER_CERT_PATH=/nonexistent/certs DOCKER_HOST=tcp://127.0.0.1:2376

# before
$ k3d-main version
Failed to initialize: unable to resolve docker endpoint: open /nonexistent/certs/ca.pem: no such file or directory
exit=1

# after
$ k3d-fixed version
k3d version v5-dev
k3s version v1.35.5-k3s1 (default)
exit=0
```

Regression check with the same broken environment — runtime-requiring commands must still fail, and they do:

```
$ k3d-fixed cluster list
Failed to initialize: unable to resolve docker endpoint: open /nonexistent/certs/ca.pem: no such file or directory
exit=1
```

With a working daemon, `k3d cluster list` behaves normally. `k3d completion bash` and `k3d version list k3s` both produce their usual output with the broken environment.

## Tests

New `cmd/root_test.go` drives the real command tree via `rootCmd.Find(...)` and asserts which commands require runtime init — `version`, `version list`, `completion` and root do not; `cluster create` and `node list` do. Confirmed failing against a stub before the annotations were added.

`go test ./...` passes, `gofmt`/`go vet` are clean, and `docgen` still compiles. I couldn't run `golangci-lint` locally, so please let CI cover that.

## Note

`k3d config migrate` arguably belongs on the annotated list too — it only transforms a YAML file (see #1477, where the runtime info debug line shows up in its trace output). I left it out to keep this focused; happy to add it here or in a follow-up if you'd like.
