### PR TITLE
feat: add --expose-nodeports flag to cluster create

### DIFF
--- a/cmd/cluster/clusterCreate.go
+++ b/cmd/cluster/clusterCreate.go
@@ -242,6 +242,9 @@ func NewCmdClusterCreate() *cobra.Command {
 	cmd.Flags().StringArrayP("port", "p", nil, "Map ports from the node containers (via the serverlb) to the host (Format: `[HOST:][HOSTPORT:]CONTAINERPORT[/PROTOCOL][@NODEFILTER]`)\n - Example: `k3d cluster create --agents 2 -p 8080:80@agent:0 -p 8081@agent:1`")
 	_ = ppViper.BindPFlag("cli.ports", cmd.Flags().Lookup("port"))
 
+	cmd.Flags().Bool("expose-nodeports", false, fmt.Sprintf("Expose the whole default k3s NodePort range (%s) on the server node, mapped to the same range on the host\n - Shorthand for --port %s:%s@server:0", k3d.DefaultNodePortRange, k3d.DefaultNodePortRange, k3d.DefaultNodePortRange))
+	_ = ppViper.BindPFlag("cli.expose-nodeports", cmd.Flags().Lookup("expose-nodeports"))
+
 	cmd.Flags().StringArrayP("k3s-node-label", "", nil, "Add label to k3s node (Format: `KEY[=VALUE][@NODEFILTER[;NODEFILTER...]]`\n - Example: `k3d cluster create --agents 2 --k3s-node-label \"my.label@agent:0,1\" --k3s-node-label \"other.label=somevalue@server:0\"`")
 	_ = ppViper.BindPFlag("cli.k3s-node-labels", cmd.Flags().Lookup("k3s-node-label"))
 
@@ -457,6 +460,14 @@ func applyCLIOverrides(cfg conf.SimpleConfig) (conf.SimpleConfig, error) {
 	}
 
 	l.Log().Tracef("PortFilterMap: %+v", portFilterMap)
+
+	// --expose-nodeports maps the whole default k3s NodePort range to the same range on the host (server node only)
+	if ppViper.GetBool("cli.expose-nodeports") {
+		cfg.Ports = append(cfg.Ports, conf.PortWithNodeFilters{
+			Port:        fmt.Sprintf("%s:%s", k3d.DefaultNodePortRange, k3d.DefaultNodePortRange),
+			NodeFilters: []string{"server:0"},
+		})
+	}
 
 	// --k3s-node-label
 	// k3sNodeLabelFilterMap will add k3s node label to applied node filters

--- a/cmd/cluster/clusterCreate_test.go
+++ b/cmd/cluster/clusterCreate_test.go
@@ -1,0 +1,66 @@
+/*
+Copyright © 2020-2023 The k3d Author(s)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package cluster
+
+import (
+	"testing"
+
+	"github.com/spf13/viper"
+
+	conf "github.com/k3d-io/k3d/v5/pkg/config/v1alpha5"
+	k3d "github.com/k3d-io/k3d/v5/pkg/types"
+)
+
+func TestApplyCLIOverridesExposeNodeports(t *testing.T) {
+	t.Run("disabled by default", func(t *testing.T) {
+		ppViper = viper.New()
+
+		cfg, err := applyCLIOverrides(conf.SimpleConfig{})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(cfg.Ports) != 0 {
+			t.Fatalf("expected no port mappings, got %+v", cfg.Ports)
+		}
+	})
+
+	t.Run("maps the nodeport range to server:0 when enabled", func(t *testing.T) {
+		ppViper = viper.New()
+		ppViper.Set("cli.expose-nodeports", true)
+
+		cfg, err := applyCLIOverrides(conf.SimpleConfig{})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(cfg.Ports) != 1 {
+			t.Fatalf("expected exactly one port mapping, got %+v", cfg.Ports)
+		}
+
+		want := k3d.DefaultNodePortRange + ":" + k3d.DefaultNodePortRange
+		if cfg.Ports[0].Port != want {
+			t.Errorf("expected port %q, got %q", want, cfg.Ports[0].Port)
+		}
+		if len(cfg.Ports[0].NodeFilters) != 1 || cfg.Ports[0].NodeFilters[0] != "server:0" {
+			t.Errorf("expected node filter [server:0], got %+v", cfg.Ports[0].NodeFilters)
+		}
+	})
+}

--- a/docs/usage/commands/k3d_cluster_create.md
+++ b/docs/usage/commands/k3d_cluster_create.md
@@ -27,6 +27,8 @@ k3d cluster create NAME [flags]
   -c, --config string                                                  Path of a config file to use
   -e, --env KEY[=VALUE][@NODEFILTER[;NODEFILTER...]]                   Add environment variables to nodes (Format: KEY[=VALUE][@NODEFILTER[;NODEFILTER...]]
                                                                         - Example: `k3d cluster create --agents 2 -e "HTTP_PROXY=my.proxy.com@server:0" -e "SOME_KEY=SOME_VAL@server:0"`
+      --expose-nodeports                                               Expose the whole default k3s NodePort range (30000-32767) on the server node, mapped to the same range on the host
+                                                                        - Shorthand for --port 30000-32767:30000-32767@server:0
       --gpus string                                                    GPU devices to add to the cluster node containers ('all' to pass all GPUs) [From docker]
   -h, --help                                                           help for create
       --host-alias ip:host[,host,...]                                  Add ip:host[,host,...] mappings

--- a/docs/usage/exposing_services.md
+++ b/docs/usage/exposing_services.md
@@ -65,7 +65,7 @@ Therefore, we have to create the cluster in a way, that the internal port 80 (wh
   `#!bash k3d cluster create mycluster -p "8082:30080@agent:0" --agents 2`
 
   - **Note 1**: Kubernetes' default NodePort range is [`30000-32767`](https://kubernetes.io/docs/concepts/services-networking/service/#nodeport)
-  - **Note 2**: You may as well expose the whole NodePort range from the very beginning, e.g. via `k3d cluster create mycluster --agents 3 -p "30000-32767:30000-32767@server:0"` (See [this video from @portainer](https://www.youtube.com/watch?v=5HaU6338lAk))
+  - **Note 2**: You may as well expose the whole NodePort range from the very beginning, e.g. via `k3d cluster create mycluster --agents 3 -p "30000-32767:30000-32767@server:0"` (See [this video from @portainer](https://www.youtube.com/watch?v=5HaU6338lAk)). The `--expose-nodeports` flag is a shorthand for exactly this mapping, so `k3d cluster create mycluster --agents 3 --expose-nodeports` does the same thing.
     - **Warning**: Docker creates iptable entries and a new proxy process per port-mapping, so this may take a very long time or even freeze your system!
 
     ... (Steps 2 and 3 like above) ...

--- a/pkg/types/defaults.go
+++ b/pkg/types/defaults.go
@@ -85,6 +85,9 @@ const DefaultAPIPort = "6443"
 // DefaultAPIHost defines the default host (IP) for the Kubernetes API
 const DefaultAPIHost = "0.0.0.0"
 
+// DefaultNodePortRange defines the default Kubernetes NodePort range (used by --expose-nodeports)
+const DefaultNodePortRange = "30000-32767"
+
 // GetDefaultObjectName prefixes the passed name with the default prefix
 func GetDefaultObjectName(name string) string {
 	return fmt.Sprintf("%s-%s", DefaultObjectNamePrefix, name)


### PR DESCRIPTION
# What

Adds an `--expose-nodeports` flag to `k3d cluster create`. When set, it maps the whole default k3s NodePort range (30000-32767) to the same port range on the host, on `server:0`. It's just a shorthand for `--port 30000-32767:30000-32767@server:0`, which is the manual workaround we already document.

Off by default, so nothing changes unless you pass the flag.

# Why

Closes #326. This came up a while back (the portainer video etc.) and the conclusion in the issue was to add an optional flag rather than exposing the range by default, since mapping the whole range is expensive. This does exactly that.

# Implications

CLI only (cmd/), additive. No change to existing behavior when the flag isn't given. Added a small unit test around applyCLIOverrides and regenerated the cluster create command docs, plus a note in the exposing-services guide.