### PR TITLE
fix: guard version list limit bounds

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -380,9 +380,7 @@ func NewCmdVersionLs() *cobra.Command {
 				})
 			}
 
-			if flags.limit > 0 {
-				filteredTags = filteredTags[0:flags.limit]
-			}
+			filteredTags = limitTags(filteredTags, flags.limit)
 			fmt.Println(strings.Join(filteredTags, "\n"))
 		},
 	}
@@ -396,6 +394,13 @@ func NewCmdVersionLs() *cobra.Command {
 	cmd.Flags().IntVarP(&flags.limit, "limit", "l", 0, "Limit number of tags in output (0 = unlimited)")
 
 	return cmd
+}
+
+func limitTags(tags []string, limit int) []string {
+	if limit > 0 && limit < len(tags) {
+		return tags[:limit]
+	}
+	return tags
 }
 
 // NewCmdCompletion creates a new completion command

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,0 +1,32 @@
+/*
+Copyright © 2020-2023 The k3d Author(s)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLimitTagsWithNoMatches(t *testing.T) {
+	assert.Empty(t, limitTags([]string{}, 1))
+}


### PR DESCRIPTION
Applying `--limit` currently slices the filtered tag list without checking its length. When the filters return no matches, `version list` panics instead of producing empty output.

Cap the slice at the available tag count and cover the empty-result case with a regression test.

Fixes #1662

Tested with `make test`, `make check`, and `make build`.